### PR TITLE
Add detail about limitation in voting contract to fix #12478

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -193,5 +193,8 @@ of votes.
 Possible Improvements
 =====================
 
-Currently, many transactions are needed to assign the rights
-to vote to all participants. Can you think of a better way?
+Currently, many transactions are needed to
+assign the rights to vote to all participants.
+Moreover, if two or more proposals have the same
+number of votes, ``winningProposal()`` is not able
+to register a tie. Can you think of a way to fix these issues?


### PR DESCRIPTION
Fixes #12478

Just included some more detail on the winningProposal() function not handling a tie correctly