### PR TITLE
Can convert `StateMutability` from string

### DIFF
--- a/libsolidity/ast/ASTEnums.h
+++ b/libsolidity/ast/ASTEnums.h
@@ -36,11 +36,24 @@ enum class VirtualLookup { Static, Virtual, Super };
 // How a function can mutate the EVM state.
 enum class StateMutability { Pure, View, NonPayable, Payable };
 
-/// Visibility ordered from restricted to unrestricted.
-enum class Visibility { Default, Private, Internal, Public, External };
+/// @param _stateMutability The state mutability string to convert.
+/// @return The corresponding StateMutability enum value.
+inline StateMutability stateMutabilityFromString(std::string const& _stateMutability)
+{
+	if (_stateMutability == "pure")
+		return StateMutability::Pure;
+	else if (_stateMutability == "view")
+		return StateMutability::View;
+	else if (_stateMutability == "nonpayable")
+		return StateMutability::NonPayable;
+	else if (_stateMutability == "payable")
+		return StateMutability::Payable;
+	else
+		solAssert(false, "Unknown state mutability \"" + _stateMutability + "\"");
+}
 
-enum class Arithmetic { Checked, Wrapping };
-
+/// @param _stateMutability The state mutability enum value to convert to string.
+/// @return The string representation of the state mutability.
 inline std::string stateMutabilityToString(StateMutability const& _stateMutability)
 {
 	switch (_stateMutability)
@@ -57,6 +70,11 @@ inline std::string stateMutabilityToString(StateMutability const& _stateMutabili
 		solAssert(false, "Unknown state mutability.");
 	}
 }
+
+/// Visibility ordered from restricted to unrestricted.
+enum class Visibility { Default, Private, Internal, Public, External };
+
+enum class Arithmetic { Checked, Wrapping };
 
 class Type;
 

--- a/libsolidity/ast/ASTEnums.h
+++ b/libsolidity/ast/ASTEnums.h
@@ -36,27 +36,25 @@ enum class VirtualLookup { Static, Virtual, Super };
 // How a function can mutate the EVM state.
 enum class StateMutability { Pure, View, NonPayable, Payable };
 
+/// State mutability names used for conversion from and to std::string.
+static constexpr std::array<std::string, 4> STATE_MUTABILITY_NAMES  = { "pure", "view", "nonpayable", "payable" };
+
+inline constexpr StateMutability stateMutabilityFromString(std::string const& _stateMutability)
+{
+	auto it = std::ranges::find(STATE_MUTABILITY_NAMES, _stateMutability);
+	solAssert(it != STATE_MUTABILITY_NAMES.end(), "Unknown state mutability \"" + _stateMutability + "\"");
+	return static_cast<StateMutability>(std::ranges::distance(STATE_MUTABILITY_NAMES.begin(), it));
+}
+
+inline constexpr std::string stateMutabilityToString(StateMutability const& _stateMutability)
+{
+	return STATE_MUTABILITY_NAMES[static_cast<std::size_t>(_stateMutability)];
+}
+
 /// Visibility ordered from restricted to unrestricted.
 enum class Visibility { Default, Private, Internal, Public, External };
 
 enum class Arithmetic { Checked, Wrapping };
-
-inline std::string stateMutabilityToString(StateMutability const& _stateMutability)
-{
-	switch (_stateMutability)
-	{
-	case StateMutability::Pure:
-		return "pure";
-	case StateMutability::View:
-		return "view";
-	case StateMutability::NonPayable:
-		return "nonpayable";
-	case StateMutability::Payable:
-		return "payable";
-	default:
-		solAssert(false, "Unknown state mutability.");
-	}
-}
 
 class Type;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,7 @@ set(libsolidity_sources
     libsolidity/AnalysisFramework.cpp
     libsolidity/AnalysisFramework.h
     libsolidity/Assembly.cpp
+	libsolidity/ASTEnums.cpp
     libsolidity/ASTJSONTest.cpp
     libsolidity/ASTJSONTest.h
     libsolidity/ErrorCheck.cpp

--- a/test/libsolidity/ASTEnums.cpp
+++ b/test/libsolidity/ASTEnums.cpp
@@ -1,0 +1,56 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Unit tests for libsolidity/interface/Common.h
+
+#include <libsolidity/ast/ASTEnums.h>
+
+#include <test/libsolidity/util/SoltestErrors.h>
+
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace solidity::util;
+
+#define TEST_CASE_NAME (boost::unit_test::framework::current_test_case().p_name)
+
+namespace solidity::frontend::test
+{
+
+BOOST_AUTO_TEST_SUITE(ASTEnumsTest)
+
+BOOST_AUTO_TEST_CASE(stateMutabilityFromString_returns_correct_enum)
+{
+	BOOST_CHECK(stateMutabilityFromString("pure") == StateMutability::Pure);
+	BOOST_CHECK(stateMutabilityFromString("view") == StateMutability::View);
+	BOOST_CHECK(stateMutabilityFromString("nonpayable") == StateMutability::NonPayable);
+	BOOST_CHECK(stateMutabilityFromString("payable") == StateMutability::Payable);
+}
+
+BOOST_AUTO_TEST_CASE(stateMutabilityToString_returns_correct_string)
+{
+	BOOST_CHECK_EQUAL(stateMutabilityToString(StateMutability::Pure), "pure");
+	BOOST_CHECK_EQUAL(stateMutabilityToString(StateMutability::View), "view");
+	BOOST_CHECK_EQUAL(stateMutabilityToString(StateMutability::NonPayable), "nonpayable");
+	BOOST_CHECK_EQUAL(stateMutabilityToString(StateMutability::Payable), "payable");
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace solidity::frontend::test


### PR DESCRIPTION
Part of #16394. Depends on #16585.

## Description
In order to deserialize `StateMutability` from JSON, a method that allows parsing it from string was introduced. It follows the pattern that was used in #16585, which defines the mapping once and then uses this for the conversion from and to `std::string`.


## AI Disclosure

- assisted with writing unit tests