### PR TITLE
Fix unset internal function pointer retrieval from packed storage slot with a subsequent non-zero variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Compiler Features:
 
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
+* Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 
 Build System:

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -242,6 +242,8 @@ void GenericStorageItem<IsTransient>::retrieveValue(langutil::SourceLocation con
 		if (type->category() == Type::Category::UserDefinedValueType)
 			type = type->encodingType();
 		bool cleaned = false;
+		// Load the slot value at storage_key and shift it to the right using storage_offset.
+		// Note that storage_offset is in bytes, so we need to shift by 8 * storage_offset bits.
 		m_context
 			<< Instruction::SWAP1 << s_loadInstruction << Instruction::SWAP1
 			<< u256(0x100) << Instruction::EXP << Instruction::SWAP1 << Instruction::DIV;
@@ -257,6 +259,9 @@ void GenericStorageItem<IsTransient>::retrieveValue(langutil::SourceLocation con
 			}
 			else if (fun->kind() == FunctionType::Kind::Internal)
 			{
+				// Mask out the upper bits not belonging to the value of the function pointer.
+				m_context << ((u256(0x1) << (8 * type->storageBytes())) - 1) << Instruction::AND;
+				cleaned = true;
 				m_context << Instruction::DUP1 << Instruction::ISZERO;
 				CompilerUtils(m_context).pushZeroValue(*fun);
 				m_context << Instruction::MUL << Instruction::OR;

--- a/test/cmdlineTests/optimizer_inliner_dynamic_reference/output
+++ b/test/cmdlineTests/optimizer_inliner_dynamic_reference/output
@@ -112,15 +112,20 @@ sub_0: assembly {
         /* "input.sol":295:298  x() */
       tag_19
       swap1
-        /* "input.sol":295:296  x */
-      dup1
-      iszero
-      tag_20
-      mul
-      or
-        /* "input.sol":295:298  x() */
       0xffffffff
+        /* "input.sol":295:296  x */
+      tag_20
+      0xffffffffffffffff
+      dup4
       and
+      iszero
+      mul
+        /* "input.sol":295:298  x() */
+      dup2
+      and
+      swap2
+      and
+      or
       jump	// in
     tag_19:
         /* "input.sol":295:302  x() + 1 */

--- a/test/cmdlineTests/optimizer_inliner_dynamic_reference_constructor/output
+++ b/test/cmdlineTests/optimizer_inliner_dynamic_reference_constructor/output
@@ -117,15 +117,20 @@ sub_0: assembly {
         /* "input.sol":289:292  x() */
       tag_16
       swap1
-        /* "input.sol":289:290  x */
-      dup1
-      iszero
-      tag_17
-      mul
-      or
-        /* "input.sol":289:292  x() */
       0xffffffff
+        /* "input.sol":289:290  x */
+      tag_17
+      0xffffffffffffffff
+      dup4
       and
+      iszero
+      mul
+        /* "input.sol":289:292  x() */
+      dup2
+      and
+      swap2
+      and
+      or
       jump	// in
     tag_16:
         /* "input.sol":289:296  x() + 1 */

--- a/test/libsolidity/semanticTests/functionTypes/call_to_zero_initialized_function_type_legacy.sol
+++ b/test/libsolidity/semanticTests/functionTypes/call_to_zero_initialized_function_type_legacy.sol
@@ -24,4 +24,8 @@ contract C {
 // ====
 // compileViaYul: false
 // ----
-// t() -> FAILURE
+// t() -> FAILURE, hex"4e487b71", 0x51
+// gas legacy: 77534
+// gas legacy code: 69600
+// gas legacyOptimized: 76677
+// gas legacyOptimized code: 28600

--- a/test/libsolidity/semanticTests/functionTypes/store_function.sol
+++ b/test/libsolidity/semanticTests/functionTypes/store_function.sol
@@ -29,5 +29,5 @@ contract C {
 // gas irOptimized code: 19000
 // gas legacy: 79492
 // gas legacy code: 69600
-// gas legacyOptimized: 77587
+// gas legacyOptimized: 77611
 // gas legacyOptimized code: 28600

--- a/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_storage_function_pointer_comparison.sol
+++ b/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_storage_function_pointer_comparison.sol
@@ -1,0 +1,22 @@
+contract C {
+    uint32 public x = 1;
+    function() internal internalFunctionPointer;
+    uint32 private y = 2;
+
+    function testComparison() public view returns (bool) {
+        function() internal uninitializedPointer;
+        if (internalFunctionPointer == uninitializedPointer)
+            return true;
+        return false;
+    }
+    function testLocalAssignment() public view returns (bool) {
+        function() internal uninitializedPointer;
+        function() internal localPointer = internalFunctionPointer;
+        if (localPointer == uninitializedPointer)
+            return true;
+        return false;
+    }
+}
+// ----
+// testComparison() -> true
+// testLocalAssignment() -> true

--- a/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_storage_function_pointer_slot_edges.sol
+++ b/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_storage_function_pointer_slot_edges.sol
@@ -1,0 +1,22 @@
+contract C {
+    function() internal functionPointerSlotStart;
+    int x;
+    uint32 private y = 2;
+    function() internal functionPointerSlotEnd;
+
+    function testFunctionPointerSlotStart() public view returns (bool) {
+        function() internal uninitializedPointer;
+        if (functionPointerSlotStart == uninitializedPointer)
+            return true;
+        return false;
+    }
+    function testFunctionPointerSlotEnd() public view returns (bool) {
+        function() internal uninitializedPointer;
+        if (functionPointerSlotEnd == uninitializedPointer)
+            return true;
+        return false;
+    }
+}
+// ----
+// testFunctionPointerSlotStart() -> true
+// testFunctionPointerSlotEnd() -> true

--- a/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_transient_storage_function_pointer_comparison.sol
+++ b/test/libsolidity/semanticTests/functionTypes/uninitialized_internal_transient_storage_function_pointer_comparison.sol
@@ -1,0 +1,28 @@
+contract C {
+    uint32 public transient x;
+    function() internal transient internalFunctionPointer;
+    uint32 private transient y;
+
+    function testComparison() public returns (bool) {
+        x = 1;
+        y = 2;
+        function() internal uninitializedPointer;
+        if (internalFunctionPointer == uninitializedPointer)
+            return true;
+        return false;
+    }
+    function testLocalAssignment() public returns (bool) {
+        x = 1;
+        y = 2;
+        function() internal uninitializedPointer;
+        function() internal localPointer = internalFunctionPointer;
+        if (localPointer == uninitializedPointer)
+            return true;
+        return false;
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// testComparison() -> true
+// testLocalAssignment() -> true


### PR DESCRIPTION
Fix #16775.