### PR TITLE
Validate Unicode direction override markers in documentation comments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
+* Parser: Detect unbalanced Unicode direction override markers (e.g. `U+202E`) in documentation comments (`///` and `/** */`)
 * SMTChecker: Fix incorrect handling of constant operands of unary operations.
 
 

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -394,7 +394,7 @@ size_t Scanner::scanSingleLineDocComment()
 
 Token Scanner::skipMultiLineComment()
 {
-	size_t const startPosition = m_source.position();
+	size_t startPosition = m_source.position();
 	while (!isSourcePastEndOfInput())
 	{
 		char prevChar = m_char;

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -348,6 +348,7 @@ bool Scanner::tryScanEndOfLine()
 size_t Scanner::scanSingleLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
+	size_t const startPosition = m_source.position();
 	size_t endPosition = m_source.position();
 
 	skipWhitespaceExceptUnicodeLinebreak();
@@ -385,12 +386,15 @@ size_t Scanner::scanSingleLineDocComment()
 		advance();
 	}
 	literal.complete();
+	ScannerError const unicodeDirectionError = validateBiDiMarkup(m_source, startPosition);
+	if (unicodeDirectionError != ScannerError::NoError)
+		m_skippedComments[NextNext].error = unicodeDirectionError;
 	return endPosition;
 }
 
 Token Scanner::skipMultiLineComment()
 {
-	size_t startPosition = m_source.position();
+	size_t const startPosition = m_source.position();
 	while (!isSourcePastEndOfInput())
 	{
 		char prevChar = m_char;
@@ -416,6 +420,7 @@ Token Scanner::skipMultiLineComment()
 Token Scanner::scanMultiLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
+	size_t const startPosition = m_source.position();
 	bool endFound = false;
 	bool charsAdded = false;
 
@@ -464,8 +469,10 @@ Token Scanner::scanMultiLineDocComment()
 	literal.complete();
 	if (!endFound)
 		return setError(ScannerError::IllegalCommentTerminator);
-	else
-		return Token::CommentLiteral;
+	ScannerError const unicodeDirectionError = validateBiDiMarkup(m_source, startPosition);
+	if (unicodeDirectionError != ScannerError::NoError)
+		return setError(unicodeDirectionError);
+	return Token::CommentLiteral;
 }
 
 Token Scanner::scanSlash()
@@ -488,6 +495,8 @@ Token Scanner::scanSlash()
 			m_skippedComments[NextNext].location.sourceName = m_sourceName;
 			m_skippedComments[NextNext].token = Token::CommentLiteral;
 			m_skippedComments[NextNext].location.end = static_cast<int>(scanSingleLineDocComment());
+			if (m_skippedComments[NextNext].error != ScannerError::NoError)
+				return setError(m_skippedComments[NextNext].error);
 			return Token::Whitespace;
 		}
 		else

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -420,7 +420,7 @@ Token Scanner::skipMultiLineComment()
 Token Scanner::scanMultiLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
-	size_t const startPosition = m_source.position();
+	size_t startPosition = m_source.position();
 	bool endFound = false;
 	bool charsAdded = false;
 

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -420,7 +420,7 @@ Token Scanner::skipMultiLineComment()
 Token Scanner::scanMultiLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
-	size_t startPosition = m_source.position();
+	size_t const startPosition = m_source.position();
 	bool endFound = false;
 	bool charsAdded = false;
 

--- a/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_1.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // RLO
+        /** overflow ‮ */
+    }
+}
+// ----
+// ParserError 8936: (71-90): Mismatching directional override markers in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_2.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_2.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // PDF
+        /** underflow ‬ */
+    }
+}
+// ----
+// ParserError 8936: (71-85): Unicode direction override underflow in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_3.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_doc_unicode_direction_override_3.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure
+    {
+        // RLO PDF
+        /** ok ‮‬ */
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_1.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // RLO
+        /// overflow ‮
+    }
+}
+// ----
+// ParserError 8936: (71-92): Mismatching directional override markers in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_2.sol
+++ b/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_2.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // PDF
+        /// underflow ‬
+    }
+}
+// ----
+// ParserError 8936: (71-85): Unicode direction override underflow in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_3.sol
+++ b/test/libsolidity/syntaxTests/comments/singleline_doc_unicode_direction_override_3.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure
+    {
+        // RLO PDF
+        /// ok ‮‬
+    }
+}
+// ----


### PR DESCRIPTION
## Description

I tried to make this MINIMAL and SANE and SIMPLE. I really hope this can be reviewed within reasonable time.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [ ] No AI tools were used
- [x] AI tools were used (details below)

An AI tool discovered it, and proposed a solution, I reviewed it and updated it, and reviewed it again.
