### PR TITLE
AsmJsonImporter: Replace validation asserts with proper AstImportError reported as JSONError

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
+* Standard JSON Interface: Malformed inline assembly in an AST supplied via the `SolidityAST` input is now reported as a `JSONError` instead of an internal `Exception`.
 * Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
 * Yul Optimizer: Fix incorrect removal of `returndatacopy()` operations referencing a stale result of `returndatasize()`.
 

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -50,6 +50,7 @@ struct InternalCompilerError: virtual util::Exception {};
 struct FatalError: virtual util::Exception {};
 struct UnimplementedFeatureError: virtual util::Exception {};
 struct InvalidAstError: virtual util::Exception {};
+struct AstImportError: virtual util::Exception {};
 
 
 /// Assertion that throws an InternalCompilerError containing the given description if it is not met.

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1482,6 +1482,11 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 				if (binariesRequested)
 					compilerStack.compile();
 			}
+			catch (AstImportError const&)
+			{
+				// Rethrow to let the outer handler classify it as a JSONError.
+				throw;
+			}
 			catch (util::Exception const& _exc)
 			{
 				solThrow(util::Exception, "Failed to import AST: "s + _exc.what());
@@ -1524,6 +1529,16 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 			Error::Type::YulException,
 			"general",
 			"" // No prefix needed. These messages already say it's a "stack too deep" error.
+		));
+	}
+	catch (AstImportError const& _exception)
+	{
+		errors.emplace_back(formatErrorWithException(
+			compilerStack,
+			_exception,
+			Error::Type::JSONError,
+			"general",
+			"Failed to import AST"
 		));
 	}
 	catch (InternalCompilerError const&)

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -32,6 +32,10 @@
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/Scanner.h>
 
+#include <libsolutil/Exceptions.h>
+
+#include <fmt/format.h>
+
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -46,7 +50,7 @@ using SourceLocation = langutil::SourceLocation;
 
 SourceLocation const AsmJsonImporter::createSourceLocation(Json const& _node)
 {
-	yulAssert(member(_node, "src").is_string(), "'src' must be a string");
+	solRequire(member(_node, "src").is_string(), AstImportError, "'src' must be a string");
 
 	return solidity::langutil::parseSourceLocation(_node["src"].get<std::string>(), m_sourceNames);
 }
@@ -61,7 +65,7 @@ T AsmJsonImporter::createAsmNode(Json const& _node)
 {
 	T r;
 	SourceLocation nativeLocation = createSourceLocation(_node);
-	yulAssert(nativeLocation.hasText(), "Invalid source location in Asm AST");
+	solRequire(nativeLocation.hasText(), AstImportError, "Invalid source location in Asm AST");
 	// TODO: We should add originLocation to the AST.
 	// While it's not included, we'll use nativeLocation for it because we only support importing
 	// inline assembly as a part of a Solidity AST and there these locations are always the same.
@@ -76,20 +80,24 @@ Json AsmJsonImporter::member(Json const& _node, std::string const& _name)
 	return _node[_name];
 }
 
+std::string AsmJsonImporter::requiredString(Json const& _node, std::string const& _name)
+{
+	Json const value = member(_node, _name);
+	solRequire(value.is_string(), AstImportError, fmt::format("Expected \"{}\" to be a string.", _name));
+	return value.get<std::string>();
+}
+
 NameWithDebugData AsmJsonImporter::createNameWithDebugData(Json const& _node)
 {
 	auto nameWithDebugData = createAsmNode<NameWithDebugData>(_node);
-	nameWithDebugData.name = YulName{member(_node, "name").get<std::string>()};
+	nameWithDebugData.name = YulName{requiredString(_node, "name")};
 	return nameWithDebugData;
 }
 
 Statement AsmJsonImporter::createStatement(Json const& _node)
 {
-	Json jsonNodeType = member(_node, "nodeType");
-	yulAssert(jsonNodeType.is_string(), "Expected \"nodeType\" to be of type string!");
-	std::string nodeType = jsonNodeType.get<std::string>();
-
-	yulAssert(nodeType.substr(0, 3) == "Yul", "Invalid nodeType prefix");
+	std::string nodeType = requiredString(_node, "nodeType");
+	solRequire(nodeType.substr(0, 3) == "Yul", AstImportError, "Invalid nodeType prefix");
 	nodeType = nodeType.substr(3);
 
 	if (nodeType == "ExpressionStatement")
@@ -115,7 +123,7 @@ Statement AsmJsonImporter::createStatement(Json const& _node)
 	else if (nodeType == "Block")
 		return createBlock(_node);
 	else
-		yulAssert(false, "Invalid nodeType as statement");
+		solThrow(AstImportError, "Invalid nodeType as statement");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
 	util::unreachable();
@@ -123,11 +131,8 @@ Statement AsmJsonImporter::createStatement(Json const& _node)
 
 Expression AsmJsonImporter::createExpression(Json const& _node)
 {
-	Json jsonNodeType = member(_node, "nodeType");
-	yulAssert(jsonNodeType.is_string(), "Expected \"nodeType\" to be of type string!");
-	std::string nodeType = jsonNodeType.get<std::string>();
-
-	yulAssert(nodeType.substr(0, 3) == "Yul", "Invalid nodeType prefix");
+	std::string nodeType = requiredString(_node, "nodeType");
+	solRequire(nodeType.substr(0, 3) == "Yul", AstImportError, "Invalid nodeType prefix");
 	nodeType = nodeType.substr(3);
 
 	if (nodeType == "FunctionCall")
@@ -137,7 +142,7 @@ Expression AsmJsonImporter::createExpression(Json const& _node)
 	else if (nodeType == "Literal")
 		return createLiteral(_node);
 	else
-		yulAssert(false, "Invalid nodeType as expression");
+		solThrow(AstImportError, "Invalid nodeType as expression");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
 	util::unreachable();
@@ -169,21 +174,21 @@ Block AsmJsonImporter::createBlock(Json const& _node)
 Literal AsmJsonImporter::createLiteral(Json const& _node)
 {
 	auto lit = createAsmNode<Literal>(_node);
-	std::string kind = member(_node, "kind").get<std::string>();
+	std::string kind = requiredString(_node, "kind");
 
-	solAssert(member(_node, "hexValue").is_string() || member(_node, "value").is_string(), "");
 	std::string value;
 	if (_node.contains("hexValue"))
-		value = util::asString(util::fromHex(member(_node, "hexValue").get<std::string>()));
+		value = util::asString(util::fromHex(requiredString(_node, "hexValue")));
 	else
-		value = member(_node, "value").get<std::string>();
+		value = requiredString(_node, "value");
 	{
 		auto const typeNode = member(_node, "type");
-		yulAssert(
-			typeNode.empty() || typeNode.get<std::string>().empty(),
+		solRequire(
+			typeNode.empty() || (typeNode.is_string() && typeNode.get<std::string>().empty()),
+			AstImportError,
 			fmt::format(
-				"Expected literal types to be either empty or absent in the JSON. Got \"{}\".",
-				typeNode.get<std::string>()
+				"Expected literal types to be either empty or absent in the JSON. Got {}.",
+				typeNode.dump()
 			)
 		);
 	}
@@ -192,8 +197,9 @@ Literal AsmJsonImporter::createLiteral(Json const& _node)
 		langutil::CharStream charStream(value, "");
 		langutil::Scanner scanner{charStream};
 		lit.kind = LiteralKind::Number;
-		yulAssert(
+		solRequire(
 			scanner.currentToken() == Token::Number,
+			AstImportError,
 			"Expected number but got " + langutil::TokenTraits::friendlyName(scanner.currentToken()) + std::string(" while scanning ") + value
 		);
 	}
@@ -202,27 +208,29 @@ Literal AsmJsonImporter::createLiteral(Json const& _node)
 		langutil::CharStream charStream(value, "");
 		langutil::Scanner scanner{charStream};
 		lit.kind = LiteralKind::Boolean;
-		yulAssert(
+		solRequire(
 			scanner.currentToken() == Token::TrueLiteral ||
 			scanner.currentToken() == Token::FalseLiteral,
+			AstImportError,
 			"Expected true/false literal!"
 		);
 	}
 	else if (kind == "string")
 	{
 		lit.kind = LiteralKind::String;
-		yulAssert(
+		solRequire(
 			value.size() <= 32,
+			AstImportError,
 			"String literal too long (" + std::to_string(value.size()) + " > 32)"
 		);
 	}
 	else
-		yulAssert(false, "unknown type of literal");
+		solThrow(AstImportError, "unknown type of literal");
 
 	// import only for inline assembly, no unlimited string literals there
 	lit.value = valueOfLiteral(value, lit.kind, false /* _unlimitedLiteralArgument */);
 
-	yulAssert(validLiteral(lit));
+	solRequire(validLiteral(lit), AstImportError, "Invalid literal value.");
 	return lit;
 }
 
@@ -234,7 +242,7 @@ Leave AsmJsonImporter::createLeave(Json const& _node)
 Identifier AsmJsonImporter::createIdentifier(Json const& _node)
 {
 	auto identifier = createAsmNode<Identifier>(_node);
-	identifier.name = YulName(member(_node, "name").get<std::string>());
+	identifier.name = YulName(requiredString(_node, "name"));
 	return identifier;
 }
 
@@ -258,7 +266,7 @@ FunctionCall AsmJsonImporter::createFunctionCall(Json const& _node)
 		functionCall.arguments.emplace_back(createExpression(var));
 
 	auto const functionNameNode = member(_node, "functionName");
-	auto const name = member(functionNameNode, "name").get<std::string>();
+	auto const name = requiredString(functionNameNode, "name");
 	if (std::optional<BuiltinHandle> builtinHandle = m_dialect.findBuiltin(name))
 	{
 		auto builtin = createAsmNode<BuiltinName>(functionNameNode);
@@ -293,7 +301,7 @@ VariableDeclaration AsmJsonImporter::createVariableDeclaration(Json const& _node
 FunctionDefinition AsmJsonImporter::createFunctionDefinition(Json const& _node)
 {
 	auto funcDef = createAsmNode<FunctionDefinition>(_node);
-	funcDef.name = YulName{member(_node, "name").get<std::string>()};
+	funcDef.name = YulName{requiredString(_node, "name")};
 
 	if (_node.contains("parameters"))
 		for (auto const& var: member(_node, "parameters"))
@@ -320,7 +328,11 @@ Case AsmJsonImporter::createCase(Json const& _node)
 	auto caseStatement = createAsmNode<Case>(_node);
 	auto const& value = member(_node, "value");
 	if (value.is_string())
-		yulAssert(value.get<std::string>() == "default", "Expected default case");
+	{
+		// NOTE: The braces are essential. solRequire() expands to an if statement and would
+		// otherwise steal the else branch below.
+		solRequire(value.get<std::string>() == "default", AstImportError, "Expected default case");
+	}
 	else
 		caseStatement.value = std::make_unique<Literal>(createLiteral(value));
 	caseStatement.body = createBlock(member(_node, "body"));

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -50,9 +50,12 @@ private:
 	langutil::SourceLocation const createSourceLocation(Json const& _node);
 	template <class T>
 	T createAsmNode(Json const& _node);
-	/// helper function to access member functions of the JSON
-	/// and throw an error if it does not exist
+	/// helper function to access a member of the JSON node;
+	/// returns a null value if the member does not exist
 	Json member(Json const& _node, std::string const& _name);
+	/// Retrieves the value of the given member of a JSON node.
+	/// Throws AstImportError if the member is missing or not a string.
+	std::string requiredString(Json const& _node, std::string const& _name);
 
 	yul::Block createBlock(Json const& _node);
 	yul::Statement createStatement(Json const& _node);

--- a/test/cmdlineTests/standard_import_ast_invalid_yul_statement_prefix/input.json
+++ b/test/cmdlineTests/standard_import_ast_invalid_yul_statement_prefix/input.json
@@ -1,0 +1,222 @@
+{
+	"language": "SolidityAST",
+	"sources": {
+		"A": {
+			"ast": {
+				"absolutePath": "A",
+				"exportedSymbols": {
+					"AsmTest": [
+						11
+					]
+				},
+				"id": 12,
+				"license": "GPL-3.0",
+				"nodeType": "SourceUnit",
+				"nodes": [
+					{
+						"id": 1,
+						"literals": [
+							"solidity",
+							">=",
+							"0.0"
+						],
+						"nodeType": "PragmaDirective",
+						"src": "36:22:0"
+					},
+					{
+						"abstract": false,
+						"baseContracts": [],
+						"canonicalName": "AsmTest",
+						"contractDependencies": [],
+						"contractKind": "contract",
+						"fullyImplemented": true,
+						"id": 11,
+						"linearizedBaseContracts": [
+							11
+						],
+						"name": "AsmTest",
+						"nameLocation": "68:7:0",
+						"nodeType": "ContractDefinition",
+						"nodes": [
+							{
+								"body": {
+									"id": 9,
+									"nodeType": "Block",
+									"src": "134:31:0",
+									"statements": [
+										{
+											"AST": {
+												"nativeSrc": "145:18:0",
+												"nodeType": "YulBlock",
+												"src": "145:18:0",
+												"statements": [
+													{
+														"nativeSrc": "147:14:0",
+														"nodeType": "XulAssignment",
+														"src": "147:14:0",
+														"value": {
+															"arguments": [
+																{
+																	"name": "x",
+																	"nativeSrc": "156:1:0",
+																	"nodeType": "YulIdentifier",
+																	"src": "156:1:0"
+																},
+																{
+																	"kind": "number",
+																	"nativeSrc": "159:1:0",
+																	"nodeType": "YulLiteral",
+																	"src": "159:1:0",
+																	"type": "",
+																	"value": "1"
+																}
+															],
+															"functionName": {
+																"name": "add",
+																"nativeSrc": "152:3:0",
+																"nodeType": "YulIdentifier",
+																"src": "152:3:0"
+															},
+															"nativeSrc": "152:9:0",
+															"nodeType": "YulFunctionCall",
+															"src": "152:9:0"
+														},
+														"variableNames": [
+															{
+																"name": "y",
+																"nativeSrc": "147:1:0",
+																"nodeType": "YulIdentifier",
+																"src": "147:1:0"
+															}
+														]
+													}
+												]
+											},
+											"evmVersion": "cancun",
+											"externalReferences": [
+												{
+													"declaration": 3,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "156:1:0",
+													"valueSize": 1
+												},
+												{
+													"declaration": 6,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "147:1:0",
+													"valueSize": 1
+												}
+											],
+											"id": 8,
+											"nodeType": "InlineAssembly",
+											"src": "136:27:0"
+										}
+									]
+								},
+								"functionSelector": "2fbebd38",
+								"id": 10,
+								"implemented": true,
+								"kind": "function",
+								"modifiers": [],
+								"name": "foo",
+								"nameLocation": "87:3:0",
+								"nodeType": "FunctionDefinition",
+								"parameters": {
+									"id": 4,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 3,
+											"mutability": "mutable",
+											"name": "x",
+											"nameLocation": "99:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "91:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 2,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "91:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "90:11:0"
+								},
+								"returnParameters": {
+									"id": 7,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 6,
+											"mutability": "mutable",
+											"name": "y",
+											"nameLocation": "131:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "123:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 5,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "123:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "122:11:0"
+								},
+								"scope": 11,
+								"src": "78:87:0",
+								"stateMutability": "pure",
+								"virtual": false,
+								"visibility": "public"
+							}
+						],
+						"scope": 12,
+						"src": "59:108:0",
+						"usedErrors": [],
+						"usedEvents": []
+					}
+				],
+				"src": "36:131:0"
+			}
+		}
+	},
+	"settings": {
+		"experimental": true,
+		"evmVersion": "cancun",
+		"outputSelection": {
+			"*": {
+				"*": [
+					"evm.bytecode.object"
+				]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_import_ast_invalid_yul_statement_prefix/output.json
+++ b/test/cmdlineTests/standard_import_ast_invalid_yul_statement_prefix/output.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "JSONError: Invalid nodeType prefix
+
+",
+            "message": "Failed to import AST: Invalid nodeType prefix",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ],
+    "sources": {}
+}

--- a/test/cmdlineTests/standard_import_ast_unknown_yul_statement/input.json
+++ b/test/cmdlineTests/standard_import_ast_unknown_yul_statement/input.json
@@ -1,0 +1,222 @@
+{
+	"language": "SolidityAST",
+	"sources": {
+		"A": {
+			"ast": {
+				"absolutePath": "A",
+				"exportedSymbols": {
+					"AsmTest": [
+						11
+					]
+				},
+				"id": 12,
+				"license": "GPL-3.0",
+				"nodeType": "SourceUnit",
+				"nodes": [
+					{
+						"id": 1,
+						"literals": [
+							"solidity",
+							">=",
+							"0.0"
+						],
+						"nodeType": "PragmaDirective",
+						"src": "36:22:0"
+					},
+					{
+						"abstract": false,
+						"baseContracts": [],
+						"canonicalName": "AsmTest",
+						"contractDependencies": [],
+						"contractKind": "contract",
+						"fullyImplemented": true,
+						"id": 11,
+						"linearizedBaseContracts": [
+							11
+						],
+						"name": "AsmTest",
+						"nameLocation": "68:7:0",
+						"nodeType": "ContractDefinition",
+						"nodes": [
+							{
+								"body": {
+									"id": 9,
+									"nodeType": "Block",
+									"src": "134:31:0",
+									"statements": [
+										{
+											"AST": {
+												"nativeSrc": "145:18:0",
+												"nodeType": "YulBlock",
+												"src": "145:18:0",
+												"statements": [
+													{
+														"nativeSrc": "147:14:0",
+														"nodeType": "YulTotallyUnknownThing",
+														"src": "147:14:0",
+														"value": {
+															"arguments": [
+																{
+																	"name": "x",
+																	"nativeSrc": "156:1:0",
+																	"nodeType": "YulIdentifier",
+																	"src": "156:1:0"
+																},
+																{
+																	"kind": "number",
+																	"nativeSrc": "159:1:0",
+																	"nodeType": "YulLiteral",
+																	"src": "159:1:0",
+																	"type": "",
+																	"value": "1"
+																}
+															],
+															"functionName": {
+																"name": "add",
+																"nativeSrc": "152:3:0",
+																"nodeType": "YulIdentifier",
+																"src": "152:3:0"
+															},
+															"nativeSrc": "152:9:0",
+															"nodeType": "YulFunctionCall",
+															"src": "152:9:0"
+														},
+														"variableNames": [
+															{
+																"name": "y",
+																"nativeSrc": "147:1:0",
+																"nodeType": "YulIdentifier",
+																"src": "147:1:0"
+															}
+														]
+													}
+												]
+											},
+											"evmVersion": "cancun",
+											"externalReferences": [
+												{
+													"declaration": 3,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "156:1:0",
+													"valueSize": 1
+												},
+												{
+													"declaration": 6,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "147:1:0",
+													"valueSize": 1
+												}
+											],
+											"id": 8,
+											"nodeType": "InlineAssembly",
+											"src": "136:27:0"
+										}
+									]
+								},
+								"functionSelector": "2fbebd38",
+								"id": 10,
+								"implemented": true,
+								"kind": "function",
+								"modifiers": [],
+								"name": "foo",
+								"nameLocation": "87:3:0",
+								"nodeType": "FunctionDefinition",
+								"parameters": {
+									"id": 4,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 3,
+											"mutability": "mutable",
+											"name": "x",
+											"nameLocation": "99:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "91:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 2,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "91:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "90:11:0"
+								},
+								"returnParameters": {
+									"id": 7,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 6,
+											"mutability": "mutable",
+											"name": "y",
+											"nameLocation": "131:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "123:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 5,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "123:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "122:11:0"
+								},
+								"scope": 11,
+								"src": "78:87:0",
+								"stateMutability": "pure",
+								"virtual": false,
+								"visibility": "public"
+							}
+						],
+						"scope": 12,
+						"src": "59:108:0",
+						"usedErrors": [],
+						"usedEvents": []
+					}
+				],
+				"src": "36:131:0"
+			}
+		}
+	},
+	"settings": {
+		"experimental": true,
+		"evmVersion": "cancun",
+		"outputSelection": {
+			"*": {
+				"*": [
+					"evm.bytecode.object"
+				]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_import_ast_unknown_yul_statement/output.json
+++ b/test/cmdlineTests/standard_import_ast_unknown_yul_statement/output.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "JSONError: Invalid nodeType as statement
+
+",
+            "message": "Failed to import AST: Invalid nodeType as statement",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ],
+    "sources": {}
+}

--- a/test/cmdlineTests/standard_import_ast_yul_identifier_missing_name/input.json
+++ b/test/cmdlineTests/standard_import_ast_yul_identifier_missing_name/input.json
@@ -1,0 +1,221 @@
+{
+	"language": "SolidityAST",
+	"sources": {
+		"A": {
+			"ast": {
+				"absolutePath": "A",
+				"exportedSymbols": {
+					"AsmTest": [
+						11
+					]
+				},
+				"id": 12,
+				"license": "GPL-3.0",
+				"nodeType": "SourceUnit",
+				"nodes": [
+					{
+						"id": 1,
+						"literals": [
+							"solidity",
+							">=",
+							"0.0"
+						],
+						"nodeType": "PragmaDirective",
+						"src": "36:22:0"
+					},
+					{
+						"abstract": false,
+						"baseContracts": [],
+						"canonicalName": "AsmTest",
+						"contractDependencies": [],
+						"contractKind": "contract",
+						"fullyImplemented": true,
+						"id": 11,
+						"linearizedBaseContracts": [
+							11
+						],
+						"name": "AsmTest",
+						"nameLocation": "68:7:0",
+						"nodeType": "ContractDefinition",
+						"nodes": [
+							{
+								"body": {
+									"id": 9,
+									"nodeType": "Block",
+									"src": "134:31:0",
+									"statements": [
+										{
+											"AST": {
+												"nativeSrc": "145:18:0",
+												"nodeType": "YulBlock",
+												"src": "145:18:0",
+												"statements": [
+													{
+														"nativeSrc": "147:14:0",
+														"nodeType": "YulAssignment",
+														"src": "147:14:0",
+														"value": {
+															"arguments": [
+																{
+																	"nativeSrc": "156:1:0",
+																	"nodeType": "YulIdentifier",
+																	"src": "156:1:0"
+																},
+																{
+																	"kind": "number",
+																	"nativeSrc": "159:1:0",
+																	"nodeType": "YulLiteral",
+																	"src": "159:1:0",
+																	"type": "",
+																	"value": "1"
+																}
+															],
+															"functionName": {
+																"name": "add",
+																"nativeSrc": "152:3:0",
+																"nodeType": "YulIdentifier",
+																"src": "152:3:0"
+															},
+															"nativeSrc": "152:9:0",
+															"nodeType": "YulFunctionCall",
+															"src": "152:9:0"
+														},
+														"variableNames": [
+															{
+																"name": "y",
+																"nativeSrc": "147:1:0",
+																"nodeType": "YulIdentifier",
+																"src": "147:1:0"
+															}
+														]
+													}
+												]
+											},
+											"evmVersion": "cancun",
+											"externalReferences": [
+												{
+													"declaration": 3,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "156:1:0",
+													"valueSize": 1
+												},
+												{
+													"declaration": 6,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "147:1:0",
+													"valueSize": 1
+												}
+											],
+											"id": 8,
+											"nodeType": "InlineAssembly",
+											"src": "136:27:0"
+										}
+									]
+								},
+								"functionSelector": "2fbebd38",
+								"id": 10,
+								"implemented": true,
+								"kind": "function",
+								"modifiers": [],
+								"name": "foo",
+								"nameLocation": "87:3:0",
+								"nodeType": "FunctionDefinition",
+								"parameters": {
+									"id": 4,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 3,
+											"mutability": "mutable",
+											"name": "x",
+											"nameLocation": "99:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "91:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 2,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "91:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "90:11:0"
+								},
+								"returnParameters": {
+									"id": 7,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 6,
+											"mutability": "mutable",
+											"name": "y",
+											"nameLocation": "131:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "123:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 5,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "123:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "122:11:0"
+								},
+								"scope": 11,
+								"src": "78:87:0",
+								"stateMutability": "pure",
+								"virtual": false,
+								"visibility": "public"
+							}
+						],
+						"scope": 12,
+						"src": "59:108:0",
+						"usedErrors": [],
+						"usedEvents": []
+					}
+				],
+				"src": "36:131:0"
+			}
+		}
+	},
+	"settings": {
+		"experimental": true,
+		"evmVersion": "cancun",
+		"outputSelection": {
+			"*": {
+				"*": [
+					"evm.bytecode.object"
+				]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_import_ast_yul_identifier_missing_name/output.json
+++ b/test/cmdlineTests/standard_import_ast_yul_identifier_missing_name/output.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "JSONError: Expected \"name\" to be a string.
+
+",
+            "message": "Failed to import AST: Expected \"name\" to be a string.",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ],
+    "sources": {}
+}

--- a/test/cmdlineTests/standard_import_ast_yul_src_not_string/input.json
+++ b/test/cmdlineTests/standard_import_ast_yul_src_not_string/input.json
@@ -1,0 +1,222 @@
+{
+	"language": "SolidityAST",
+	"sources": {
+		"A": {
+			"ast": {
+				"absolutePath": "A",
+				"exportedSymbols": {
+					"AsmTest": [
+						11
+					]
+				},
+				"id": 12,
+				"license": "GPL-3.0",
+				"nodeType": "SourceUnit",
+				"nodes": [
+					{
+						"id": 1,
+						"literals": [
+							"solidity",
+							">=",
+							"0.0"
+						],
+						"nodeType": "PragmaDirective",
+						"src": "36:22:0"
+					},
+					{
+						"abstract": false,
+						"baseContracts": [],
+						"canonicalName": "AsmTest",
+						"contractDependencies": [],
+						"contractKind": "contract",
+						"fullyImplemented": true,
+						"id": 11,
+						"linearizedBaseContracts": [
+							11
+						],
+						"name": "AsmTest",
+						"nameLocation": "68:7:0",
+						"nodeType": "ContractDefinition",
+						"nodes": [
+							{
+								"body": {
+									"id": 9,
+									"nodeType": "Block",
+									"src": "134:31:0",
+									"statements": [
+										{
+											"AST": {
+												"nativeSrc": "145:18:0",
+												"nodeType": "YulBlock",
+												"src": "145:18:0",
+												"statements": [
+													{
+														"nativeSrc": "147:14:0",
+														"nodeType": "YulAssignment",
+														"src": "147:14:0",
+														"value": {
+															"arguments": [
+																{
+																	"name": "x",
+																	"nativeSrc": "156:1:0",
+																	"nodeType": "YulIdentifier",
+																	"src": "156:1:0"
+																},
+																{
+																	"kind": "number",
+																	"nativeSrc": "159:1:0",
+																	"nodeType": "YulLiteral",
+																	"src": "159:1:0",
+																	"type": "",
+																	"value": "1"
+																}
+															],
+															"functionName": {
+																"name": "add",
+																"nativeSrc": "152:3:0",
+																"nodeType": "YulIdentifier",
+																"src": "152:3:0"
+															},
+															"nativeSrc": "152:9:0",
+															"nodeType": "YulFunctionCall",
+															"src": 12345
+														},
+														"variableNames": [
+															{
+																"name": "y",
+																"nativeSrc": "147:1:0",
+																"nodeType": "YulIdentifier",
+																"src": "147:1:0"
+															}
+														]
+													}
+												]
+											},
+											"evmVersion": "cancun",
+											"externalReferences": [
+												{
+													"declaration": 3,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "156:1:0",
+													"valueSize": 1
+												},
+												{
+													"declaration": 6,
+													"isOffset": false,
+													"isSlot": false,
+													"src": "147:1:0",
+													"valueSize": 1
+												}
+											],
+											"id": 8,
+											"nodeType": "InlineAssembly",
+											"src": "136:27:0"
+										}
+									]
+								},
+								"functionSelector": "2fbebd38",
+								"id": 10,
+								"implemented": true,
+								"kind": "function",
+								"modifiers": [],
+								"name": "foo",
+								"nameLocation": "87:3:0",
+								"nodeType": "FunctionDefinition",
+								"parameters": {
+									"id": 4,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 3,
+											"mutability": "mutable",
+											"name": "x",
+											"nameLocation": "99:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "91:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 2,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "91:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "90:11:0"
+								},
+								"returnParameters": {
+									"id": 7,
+									"nodeType": "ParameterList",
+									"parameters": [
+										{
+											"constant": false,
+											"id": 6,
+											"mutability": "mutable",
+											"name": "y",
+											"nameLocation": "131:1:0",
+											"nodeType": "VariableDeclaration",
+											"scope": 10,
+											"src": "123:9:0",
+											"stateVariable": false,
+											"storageLocation": "default",
+											"typeDescriptions": {
+												"typeIdentifier": "t_uint256",
+												"typeString": "uint256"
+											},
+											"typeName": {
+												"id": 5,
+												"name": "uint256",
+												"nodeType": "ElementaryTypeName",
+												"src": "123:7:0",
+												"typeDescriptions": {
+													"typeIdentifier": "t_uint256",
+													"typeString": "uint256"
+												}
+											},
+											"visibility": "internal"
+										}
+									],
+									"src": "122:11:0"
+								},
+								"scope": 11,
+								"src": "78:87:0",
+								"stateMutability": "pure",
+								"virtual": false,
+								"visibility": "public"
+							}
+						],
+						"scope": 12,
+						"src": "59:108:0",
+						"usedErrors": [],
+						"usedEvents": []
+					}
+				],
+				"src": "36:131:0"
+			}
+		}
+	},
+	"settings": {
+		"experimental": true,
+		"evmVersion": "cancun",
+		"outputSelection": {
+			"*": {
+				"*": [
+					"evm.bytecode.object"
+				]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_import_ast_yul_src_not_string/output.json
+++ b/test/cmdlineTests/standard_import_ast_yul_src_not_string/output.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "JSONError: 'src' must be a string
+
+",
+            "message": "Failed to import AST: 'src' must be a string",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ],
+    "sources": {}
+}


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

Reworked per the review feedback below: from a pure test addition into the validation fix it actually needed.

`AsmJsonImporter` parses untrusted JSON (the inline assembly subtree of ASTs supplied via the experimental `SolidityAST` standard-json input), but validated it with `yulAssert`/`solAssert`. Malformed input therefore surfaced as `"type": "Exception"` — documented as an internal failure that "should be reported as an issue" — and some unchecked accesses escaped as raw nlohmann `type_error`s.

Changes:
- Introduce `langutil::AstImportError` and throw it via `solRequire()`/`solThrow()` for every malformed-input condition in `AsmJsonImporter` (all 16 former asserts, including the message-less ones).
- Add a `requiredString()` helper for JSON string fields that were previously read unchecked (`name`, `kind`, `hexValue`, `value`, `nodeType`), so missing or mistyped fields produce a proper message instead of a raw `type_error`.
- Catch the new type in `StandardCompiler` and report it as `"type": "JSONError"` ("JSON input doesn't conform to the required format"), keeping the established `Failed to import AST: ` message prefix. The CLI path is unaffected — its broad `catch` already yields the same message.
- Replace the Boost test with four standard-json cmdline tests (`test/cmdlineTests/standard_import_ast_*`), one per validation path, including the `createStatement` nodeType prefix check linked in the review.

Example — importing an AST whose `YulAssignment` node has `"nodeType": "XulAssignment"`:
- Before: `"type": "Exception"`, message `Unknown exception during compilation: ... Failed to import AST: Invalid nodeType prefix`
- After: `"type": "JSONError"`, message `Failed to import AST: Invalid nodeType prefix`

Partially addresses #15854 (the `AsmJsonImporter` half). Out of scope, left for follow-ups: `ASTJsonImporter`'s `astAssert`s (the other half of #15854, including the related `FIXME` in `CommandLineInterface`), and non-structural value errors (invalid hex digits via `fromHex`, oversized number literals), which still surface as `Exception`.


## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used

<!-- If AI tools were used, describe which tools and for which parts here. -->
