### PR TITLE
Execution framework supports external compiler

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,7 +138,8 @@ set(libsolidity_util_sources
 	libsolidity/util/SoltestErrors.h
     libsolidity/util/SoltestTypes.h
     libsolidity/util/TestFileParser.cpp
-	libsolidity/util/StandardJSONCompiler.h
+    libsolidity/util/StandardJSONCompiler.h
+    libsolidity/util/StandardJSONCompilerAdapter.h
 	libsolidity/util/StandardJSONOutputExt.cpp
 	libsolidity/util/StandardJSONOutputExt.h
     libsolidity/util/TestFileParser.h

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -113,6 +113,7 @@ void CommonOptions::addOptions()
 		("evm-version", po::value(&evmVersionString), "which EVM version to use")
 		("testpath", po::value<fs::path>(&this->testPath)->default_value(solidity::test::testPath()), "path to test files")
 		("vm", po::value<std::vector<fs::path>>(&vmPaths), "path to evmc library, can be supplied multiple times.")
+		("solc-path", po::value<boost::optional<fs::path>>(&solcPath), "path to the solc binary to use (optional).")
 		("batches", po::value<size_t>(&this->batches)->default_value(1), "set number of batches to split the tests into")
 		("selected-batch", po::value<size_t>(&this->selectedBatch)->default_value(0), "zero-based number of batch to execute")
 		("no-semantic-tests", po::bool_switch(&disableSemanticTests)->default_value(disableSemanticTests), "disable semantic tests")
@@ -137,6 +138,21 @@ void CommonOptions::validate() const
 		ConfigException,
 		"Invalid test path specified."
 	);
+	if (solcPath)
+	{
+		solRequire(
+			!(*solcPath).empty(),
+			ConfigException,
+			"No solc path specified. The --solc-path argument must not be empty when given."
+		);
+		solRequire(
+			fs::exists(*solcPath),
+			ConfigException,
+			"Invalid solc path specified."
+		);
+		if (disableSemanticTests)
+			std::cout << std::endl << "WARNING :: Semantic tests are disabled. Setting solc path does not have an effect." << std::endl;
+	}
 	solRequire(
 		batches > 0,
 		ConfigException,
@@ -147,6 +163,7 @@ void CommonOptions::validate() const
 		ConfigException,
 		"Selected batch has to be less than number of batches."
 	);
+
 
 	if (!enforceGasTest)
 		std::cout << std::endl << "WARNING :: Gas cost expectations are not being enforced" << std::endl << std::endl;

--- a/test/Common.h
+++ b/test/Common.h
@@ -26,6 +26,7 @@
 #include <test/evmc/evmc.h>
 
 #include <boost/filesystem/path.hpp>
+#include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -58,6 +59,7 @@ struct CommonOptions
 
 	std::vector<boost::filesystem::path> vmPaths;
 	boost::filesystem::path testPath;
+	boost::optional<boost::filesystem::path> solcPath = boost::none;
 	bool optimize = false;
 	bool enforceGasTest = false;
 	u256 enforceGasTestMinValue = 100000;

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -65,7 +65,7 @@ public:
 		std::string const& _contractName = "",
 		bytes const& _arguments = {},
 		std::map<std::string, util::h160> const& _libraryAddresses = {},
-		std::optional<std::string> const& _sourceName = std::nullopt
+		std::optional<std::string> const& _mainSourceName = std::nullopt
 	) = 0;
 
 	bytes const& compileAndRun(

--- a/test/libsolidity/GasCosts.cpp
+++ b/test/libsolidity/GasCosts.cpp
@@ -19,7 +19,9 @@
  * Tests that check that the cost of certain operations stay within range.
  */
 
+#include <test/libsolidity/util/SoltestErrors.h>
 #include <test/libsolidity/SolidityExecutionFramework.h>
+
 #include <liblangutil/EVMVersion.h>
 #include <libsolutil/IpfsHash.h>
 #include <libevmasm/GasMeter.h>
@@ -38,7 +40,10 @@ namespace solidity::frontend::test
 #define CHECK_DEPLOY_GAS(_gasNoOpt, _gasOpt, _evmVersion) \
 	do \
 	{ \
-		u256 metaCost = GasMeter::dataGas(m_compiler.cborMetadata(m_compiler.lastContractName()), true, _evmVersion); \
+		auto const& output = m_compiler.output(); \
+		auto const* contract = output.contract(); \
+		soltestAssert(contract); \
+		u256 metaCost = GasMeter::dataGas(bytes{}, true, _evmVersion); \
 		u256 gasOpt{_gasOpt}; \
 		u256 gasNoOpt{_gasNoOpt}; \
 		u256 gas = m_optimiserSettings == OptimiserSettings::minimal() ? gasNoOpt : gasOpt; \
@@ -90,7 +95,7 @@ BOOST_AUTO_TEST_CASE(string_storage)
 			}
 		}
 	)";
-	m_compiler.setMetadataFormat(CompilerStack::MetadataFormat::NoMetadata);
+
 	m_appendCBORMetadata = false;
 	compileAndRun(sourceCode);
 
@@ -202,8 +207,15 @@ BOOST_AUTO_TEST_CASE(single_callvaluecheck)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Payable");
-	size_t bytecodeSizeNonpayable = m_compiler.object("Nonpayable").bytecode.size();
-	size_t bytecodeSizePayable = m_compiler.object("Payable").bytecode.size();
+	auto const& output = m_compiler.output();
+	auto const* nonpayable = output.contract("Nonpayable");
+	auto const* payable = output.contract("Payable");
+	soltestAssert(nonpayable);
+	soltestAssert(payable);
+
+
+	size_t bytecodeSizeNonpayable = nonpayable->evm.bytecode.object.size();
+	size_t bytecodeSizePayable = payable->evm.bytecode.object.size();
 
 	auto evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	if (evmVersion < EVMVersion::shanghai())

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -21,10 +21,16 @@
  * Unit tests for the gas estimator.
  */
 
+#include "libsolidity/interface/CompilerStack.h"
 #include <test/libsolidity/SolidityExecutionFramework.h>
+
+#include <test/libsolidity/util/Common.h>
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <libevmasm/GasMeter.h>
 #include <libevmasm/KnownState.h>
 #include <libevmasm/PathGasMeter.h>
+
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/interface/GasEstimator.h>
 
@@ -37,30 +43,66 @@ using namespace solidity::test;
 namespace solidity::frontend::test
 {
 
+/// All test suites inheriting from `SolidityExecutionFramework` do compile through the standard JSON interface
+/// aka. `StandardCompiler`. This suite is an exception since we can't easily restore the assembly items,
+/// that are needed to feed into the gas meter, from the JSON output.
+///
+/// TODO: The gas meter tests still use the internal interface aka. `CompilerStack` for now. Re-write as semantic tests
+/// that compile with `--gas` and test against that output.
 class GasMeterTestFramework: public SolidityExecutionFramework
 {
 public:
-	void compile(std::string const& _sourceCode)
+	bytes const& compileAndRunWithoutCheck(
+		std::map<std::string, std::string> const& _sourceCode,
+		u256 const& _value = 0,
+		std::string const& _contractName = "",
+		bytes const& _arguments = {},
+		std::map<std::string, Address> const& _libraryAddresses = {},
+		std::optional<std::string> const& _mainSourceName = std::nullopt
+	) override
 	{
-		m_compiler.reset();
-		m_compiler.setSources({{"", "pragma solidity >=0.0;\n"
-				"// SPDX-License-Identifier: GPL-3.0\n" + _sourceCode}});
-		m_compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
-		m_compiler.setEVMVersion(m_evmVersion);
-		BOOST_REQUIRE_MESSAGE(m_compiler.compile(), "Compiling contract failed");
+		bytes bytecode = multiSourceCompileContract(_sourceCode, _contractName, _libraryAddresses, _mainSourceName);
+		sendMessage(bytecode, _arguments, true, _value);
+		return m_output;
+	}
+
+
+	bytes multiSourceCompileContract(
+		std::map<std::string, std::string> const& _sources,
+		std::string const&,
+		std::map<std::string, Address> const&,
+		std::optional<std::string> const&
+	)
+	{
+		soltestAssert(_sources.contains(""), "No contract with in source unit with empty name found.");
+
+		m_compilerStack.reset();
+		m_compilerStack.setSources({{"", "pragma solidity >=0.0;\n"
+				"// SPDX-License-Identifier: GPL-3.0\n" + _sources.at("")}});
+		m_compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
+		m_compilerStack.setEVMVersion(m_evmVersion);
+
+		BOOST_REQUIRE_MESSAGE(m_compilerStack.compile(), "Compiling contract failed");
+
+		return m_compilerStack.object(m_compilerStack.lastContractName()).bytecode;
 	}
 
 	void testCreationTimeGas(std::string const& _sourceCode, u256 const& _tolerance = u256(0))
 	{
 		compileAndRun(_sourceCode);
+
 		auto state = std::make_shared<KnownState>();
-		PathGasMeter meter(*m_compiler.assemblyItems(m_compiler.lastContractName()), solidity::test::CommonOptions::get().evmVersion());
+		PathGasMeter meter(
+			*m_compilerStack.assemblyItems(m_compilerStack.lastContractName()),
+			solidity::test::CommonOptions::get().evmVersion()
+		);
+
 		GasMeter::GasConsumption gas = meter.estimateMax(0, state);
-		u256 bytecodeSize(m_compiler.runtimeObject(m_compiler.lastContractName()).bytecode.size());
+		u256 bytecodeSize(m_compilerStack.runtimeObject(m_compilerStack.lastContractName()).bytecode.size());
 		// costs for deployment
 		gas += bytecodeSize * GasCosts::createDataGas;
 		// costs for transaction
-		gas += gasForTransaction(m_compiler.object(m_compiler.lastContractName()).bytecode, true);
+		gas += gasForTransaction(m_compilerStack.object(m_compilerStack.lastContractName()).bytecode, true);
 
 		BOOST_REQUIRE(!gas.isInfinite);
 		BOOST_CHECK_LE(m_gasUsed, gas.value);
@@ -82,8 +124,8 @@ public:
 			gas = std::max(gas, gasForTransaction(hash.asBytes() + arguments, false));
 		}
 
-		gas += GasEstimator(solidity::test::CommonOptions::get().evmVersion()).functionalEstimation(
-			*m_compiler.runtimeAssemblyItems(m_compiler.lastContractName()),
+		gas += GasEstimator(CommonOptions::get().evmVersion()).functionalEstimation(
+			*m_compilerStack.runtimeAssemblyItems(m_compilerStack.lastContractName()),
 			_sig
 		);
 		BOOST_REQUIRE(!gas.isInfinite);
@@ -93,12 +135,15 @@ public:
 
 	static GasMeter::GasConsumption gasForTransaction(bytes const& _data, bool _isCreation)
 	{
-		auto evmVersion = solidity::test::CommonOptions::get().evmVersion();
+		auto evmVersion = CommonOptions::get().evmVersion();
 		GasMeter::GasConsumption gas = _isCreation ? GasCosts::txCreateGas : GasCosts::txGas;
 		for (auto i: _data)
 			gas += i != 0 ? GasCosts::txDataNonZeroGas(evmVersion) : GasCosts::txDataZeroGas;
 		return gas;
 	}
+
+private:
+	CompilerStack m_compilerStack;
 };
 
 BOOST_FIXTURE_TEST_SUITE(GasMeterTests, GasMeterTestFramework)

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -11,18 +11,32 @@
 	You should have received a copy of the GNU General Public License
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
-
 #include <test/libsolidity/SemanticTest.h>
 
-#include <libsolutil/Whiskers.h>
-#include <libyul/Exceptions.h>
+#include <libsolidity/interface/MetadataSettings.h>
+#include <libsolidity/interface/StandardJSONInput.h>
+#include "libsolidity/util/SoltestErrors.h"
+#include <ostream>
+
 #include <test/Common.h>
 #include <test/libsolidity/util/BytesUtils.h>
+#include <test/libsolidity/util/ContractABIUtils.h>
+#include <test/libsolidity/util/StandardJSONCompiler.h>
+
+#include <libsolutil/StringUtils.h>
+#include <libsolutil/Whiskers.h>
+
+#include <libyul/Exceptions.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/throw_exception.hpp>
+
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/view/join.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/range/conversion.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -33,6 +47,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 
 using namespace solidity;
 using namespace solidity::yul;
@@ -108,15 +123,20 @@ SemanticTest::SemanticTest(
 
 	m_allowNonExistingFunctions = m_reader.boolSetting("allowNonExistingFunctions", false);
 	m_testCaseWantsSSACFGRun = m_reader.boolSetting("compileViaSSACFG", true);
-	m_compiler.setExperimental(m_reader.boolSetting("experimental", m_testCaseWantsSSACFGRun));
+	if (!m_compilerInput.settings)
+		m_compilerInput.settings = input::Settings{};
+
+	m_compilerInput.settings->experimental = m_reader.boolSetting("experimental", m_testCaseWantsSSACFGRun);
 
 	parseExpectations(m_reader.stream());
 	soltestAssert(!m_tests.empty(), "No tests specified in " + _filename);
 
 	if (m_enforceGasCost)
 	{
-		m_compiler.setMetadataFormat(CompilerStack::MetadataFormat::NoMetadata);
-		m_compiler.setMetadataHash(MetadataHash::None);
+		if (!m_compilerInput.settings->metadata)
+			m_compilerInput.settings->metadata = input::Metadata{};
+		m_compilerInput.settings->metadata->appendCBOR = false;
+		m_compilerInput.settings->metadata->bytecodeHash = MetadataHash::None;
 	}
 
 	if (auto targetContract = m_reader.stringSetting("targetContract", ""); !targetContract.empty())
@@ -196,52 +216,37 @@ std::vector<SideEffectHook> SemanticTest::makeSideEffectHooks() const
 	};
 }
 
-std::string SemanticTest::formatEventParameter(std::optional<AnnotatedEventSignature> _signature, bool _indexed, size_t _index, bytes const& _data)
-{
-	auto isPrintableASCII = [](bytes const& s)
-	{
-		bool zeroes = true;
-		for (auto c: s)
-		{
-			if (static_cast<unsigned>(c) != 0x00)
-			{
-				zeroes = false;
-				if (static_cast<unsigned>(c) <= 0x1f || static_cast<unsigned>(c) >= 0x7f)
-					return false;
-			} else
-				break;
-		}
-		return !zeroes;
-	};
-
-	ABIType abiType(ABIType::Type::Hex);
-	if (isPrintableASCII(_data))
-		abiType = ABIType(ABIType::Type::String);
-	if (_signature.has_value())
-	{
-		std::vector<std::string> const& types = _indexed ? _signature->indexedTypes : _signature->nonIndexedTypes;
-		if (_index < types.size())
-		{
-			if (types.at(_index) == "bool")
-				abiType = ABIType(ABIType::Type::Boolean);
-		}
-	}
-	return BytesUtils::formatBytes(_data, abiType);
-}
-
 std::vector<std::string> SemanticTest::eventSideEffectHook(FunctionCall const&) const
 {
+	using namespace output;
+
+	auto contracts = m_compiler.output().contracts();
+	auto entries = contracts | ranges::views::transform([](auto const* contract) {
+		return ranges::views::all(contract->abi);
+	}) | ranges::views::join;
+
+	auto events = entries | ranges::views::filter([](auto const& entry) {
+		return std::holds_alternative<ABIEvent>(entry);
+	}) | ranges::views::transform([](auto const& entry) {
+		return std::get<ABIEvent>(entry);
+	}) | ranges::to<std::vector<ABIEvent>>();
+
 	std::vector<std::string> sideEffects;
-	std::vector<LogRecord> recordedLogs = ExecutionFramework::recordedLogs();
-	for (LogRecord const& log: recordedLogs)
+	for (LogRecord const& log: ExecutionFramework::recordedLogs())
 	{
-		std::optional<AnnotatedEventSignature> eventSignature;
+		ABIEvent const* event = nullptr;
 		if (!log.topics.empty())
-			eventSignature = matchEvent(log.topics[0]);
+		{
+			auto e = ranges::find_if(events, [&](auto const& _e) {
+		        return keccak256(formatSignature(_e)) == log.topics[0] && !_e.isAnonymous;
+		    });
+			event = (e != events.end()) ? &*e : nullptr;
+		}
+
 		std::stringstream sideEffect;
 		sideEffect << "emit ";
-		if (eventSignature.has_value())
-			sideEffect << eventSignature.value().signature;
+		if (event)
+			sideEffect << formatSignature(*event);
 		else
 			sideEffect << "<anonymous>";
 
@@ -252,8 +257,8 @@ std::vector<std::string> SemanticTest::eventSideEffectHook(FunctionCall const&) 
 		size_t index{0};
 		for (h256 const& topic: log.topics)
 		{
-			if (!eventSignature.has_value() || index != 0)
-				eventStrings.push_back("#" + formatEventParameter(eventSignature, true, index, topic.asBytes()));
+			if (!event || index != 0)
+				eventStrings.push_back("#" + formatEventParameter(event, true, index, topic.asBytes()));
 			++index;
 		}
 
@@ -262,7 +267,7 @@ std::vector<std::string> SemanticTest::eventSideEffectHook(FunctionCall const&) 
 		{
 			auto begin = log.data.begin() + static_cast<long>(index * 32);
 			bytes const& data = bytes{begin, begin + 32};
-			eventStrings.emplace_back(formatEventParameter(eventSignature, false, index, data));
+			eventStrings.emplace_back(formatEventParameter(event, false, index, data));
 		}
 
 		if (!eventStrings.empty())
@@ -271,31 +276,6 @@ std::vector<std::string> SemanticTest::eventSideEffectHook(FunctionCall const&) 
 		sideEffects.emplace_back(sideEffect.str());
 	}
 	return sideEffects;
-}
-
-std::optional<AnnotatedEventSignature> SemanticTest::matchEvent(util::h256 const& hash) const
-{
-	std::optional<AnnotatedEventSignature> result;
-	for (std::string& contractName: m_compiler.contractNames())
-	{
-		ContractDefinition const& contract = m_compiler.contractDefinition(contractName);
-		for (EventDefinition const* event: contract.events() + contract.usedInterfaceEvents())
-		{
-			FunctionTypePointer eventFunctionType = event->functionType(true);
-			if (!event->isAnonymous() && keccak256(eventFunctionType->externalSignature()) == hash)
-			{
-				AnnotatedEventSignature eventInfo;
-				eventInfo.signature = eventFunctionType->externalSignature();
-				for (auto const& param: event->parameters())
-					if (param->isIndexed())
-						eventInfo.indexedTypes.emplace_back(param->type()->toString(true));
-					else
-						eventInfo.nonIndexedTypes.emplace_back(param->type()->toString(true));
-				result = eventInfo;
-			}
-		}
-	}
-	return result;
 }
 
 frontend::OptimiserSettings SemanticTest::optimizerSettingsFor(RequiresYulOptimizer _requiresYulOptimizer)
@@ -377,7 +357,7 @@ TestCase::TestResult SemanticTest::runTest(
 	for (TestFunctionCall& test: m_tests)
 		test.reset();
 
-	std::map<std::string, solidity::test::Address> libraries;
+	std::map<std::string, Address> libraries;
 
 	bool constructed = false;
 
@@ -396,13 +376,14 @@ TestCase::TestResult SemanticTest::runTest(
 		}
 		else if (test.call().kind == FunctionCall::Kind::Library)
 		{
+			auto name = fmt::format("{}:{}", test.call().libraryFile, test.call().signature);
 			soltestAssert(
-				deploy(test.call().signature, 0, {}, libraries) && m_transactionSuccessful,
+				deploy(name, 0, {}, libraries) && m_transactionSuccessful,
 				"Failed to deploy library " + test.call().signature);
 			// For convenience, in semantic tests we assume that an unqualified name like `L` is equivalent to one
 			// with an empty source unit name (`:L`). This is fine because the compiler never uses unqualified
 			// names in the Yul code it produces and does not allow `linkersymbol()` at all in inline assembly.
-			libraries[test.call().libraryFile + ":" + test.call().signature] = m_contractAddress;
+			libraries[name] = m_contractAddress;
 			continue;
 		}
 		else
@@ -429,7 +410,13 @@ TestCase::TestResult SemanticTest::runTest(
 		}
 		else
 		{
+			ContractName contractName{m_sources.mainSourceFile, m_targetContract.value_or("")};
+
+			auto const* contract = m_compiler.output().contract(contractName);
+			soltestAssert(contract);
+
 			bytes output;
+
 			if (test.call().kind == FunctionCall::Kind::LowLevel)
 				output = callLowLevel(test.call().arguments.rawBytes(), test.call().value.value);
 			else if (test.call().kind == FunctionCall::Kind::Builtin)
@@ -447,7 +434,7 @@ TestCase::TestResult SemanticTest::runTest(
 			{
 				soltestAssert(
 					m_allowNonExistingFunctions ||
-					m_compiler.interfaceSymbols(m_compiler.lastContractName(m_sources.mainSourceFile))["methods"].contains(test.call().signature),
+					contract->evm.methodIdentifiers.contains(test.call().signature),
 					"The function " + test.call().signature + " is not known to the compiler"
 				);
 
@@ -474,8 +461,9 @@ TestCase::TestResult SemanticTest::runTest(
 
 			test.setFailure(!m_transactionSuccessful);
 			test.setRawBytes(std::move(output));
+
 			if (test.call().kind != FunctionCall::Kind::LowLevel)
-				test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName(m_sources.mainSourceFile)));
+				test.setContractABI(contract->abi);
 		}
 
 		std::vector<std::string> effects;

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -30,13 +30,6 @@
 namespace solidity::frontend::test
 {
 
-struct AnnotatedEventSignature
-{
-	std::string signature;
-	std::vector<std::string> indexedTypes;
-	std::vector<std::string> nonIndexedTypes;
-};
-
 enum class RequiresYulOptimizer
 {
 	False,
@@ -107,8 +100,6 @@ private:
 	std::map<std::string, Builtin> makeBuiltins();
 	std::vector<SideEffectHook> makeSideEffectHooks() const;
 	std::vector<std::string> eventSideEffectHook(FunctionCall const&) const;
-	std::optional<AnnotatedEventSignature> matchEvent(util::h256 const& hash) const;
-	static std::string formatEventParameter(std::optional<AnnotatedEventSignature> _signature, bool _indexed, size_t _index, bytes const& _data);
 
 	OptimiserSettings optimizerSettingsFor(RequiresYulOptimizer _requiresYulOptimizer);
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2815,9 +2815,14 @@ BOOST_AUTO_TEST_CASE(include_creation_bytecode_only_once)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Single");
+	auto const& output = m_compiler.output();
+	auto const* contractDouble = output.contract(std::string_view{"Double"});
+	auto const* contractSingle = output.contract("Single");
+	solAssert(contractDouble);
+	solAssert(contractSingle);
 	BOOST_CHECK_LE(
-		double(m_compiler.object("Double").bytecode.size()),
-		1.2 * double(m_compiler.object("Single").bytecode.size())
+		static_cast<double>(contractDouble->evm.bytecode.object.size()),
+		1.2 * static_cast<double>(contractSingle->evm.bytecode.object.size())
 	);
 }
 

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -23,72 +23,171 @@
 
 #include <test/libsolidity/SolidityExecutionFramework.h>
 #include <test/libsolidity/util/Common.h>
+#include <test/libsolidity/util/StandardJSONCompiler.h>
+#include <test/libsolidity/util/StandardJSONOutput.h>
+#include <test/libsolidity/util/SoltestErrors.h>
 
 #include <liblangutil/DebugInfoSelection.h>
-#include <libyul/Exceptions.h>
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/SourceReferenceFormatter.h>
+#include <libyul/Exceptions.h>
+#include <libsolidity/interface/StandardJSONInput.h>
 
 #include <boost/test/framework.hpp>
 
-#include <cstdlib>
+#include <range/v3/algorithm.hpp>
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
+
 #include <iostream>
+#include <memory>
+#include <optional>
 
 using namespace solidity;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::langutil;
-using namespace solidity::test;
+
+namespace
+{
+	std::shared_ptr<const langutil::Error> convertError(output::Error const& _error)
+	{
+		return std::make_shared<const langutil::Error>(_error.toInternalError());
+	}
+
+	std::map<std::string, std::string> convertLibraryAddresses(std::map<std::string, Address> const& _addresses)
+	{
+		return _addresses | ranges::views::transform([](auto const& entry) {
+			auto const& [libraryName, address] = entry;
+			auto parts = libraryName | ranges::views::split(':') | ranges::to<std::vector<std::string>>();
+			return std::pair{parts.back(), "0x" + address.hex()};
+		}) | ranges::to<std::map<std::string, std::string>>();
+	}
+
+	Optimizer buildOptimizerSettings(OptimiserSettings const& _settings)
+	{
+		auto yulDetails = YulOptimizerDetails{};
+		yulDetails.stackAllocation = _settings.optimizeStackAllocation;
+		yulDetails.optimizerSteps = _settings.yulOptimiserSteps;
+
+		auto details = OptimizerDetails{};
+		details.peephole = _settings.runPeephole;
+		details.inliner = _settings.runInliner;
+		details.jumpdestRemover = _settings.runJumpdestRemover;
+		details.orderLiterals = _settings.runOrderLiterals;
+		details.deduplicate = _settings.runDeduplicate;
+		details.cse = _settings.runCSE;
+		details.constantOptimizer = _settings.runConstantOptimiser;
+		details.simpleCounterForLoopUncheckedIncrement = _settings.simpleCounterForLoopUncheckedIncrement;
+		details.yul = _settings.runYulOptimiser;
+		details.yulDetails = yulDetails;
+
+		auto optimizer = Optimizer{};
+		optimizer.enable = false;
+		optimizer.runs = _settings.expectedExecutionsPerDeployment;
+		optimizer.details = details;
+
+		return optimizer;
+	}
+
+	Metadata buildMetadataSettings(bool _appendCBOR, MetadataHash const& _metadataHash)
+	{
+		auto metadata = Metadata{};
+		metadata.appendCBOR = _appendCBOR;
+		if (_appendCBOR)
+			metadata.bytecodeHash = _metadataHash;
+		return metadata;
+	}
+}
 
 bytes SolidityExecutionFramework::multiSourceCompileContract(
 	std::map<std::string, std::string> const& _sourceCode,
-	std::optional<std::string> const& _mainSourceName,
 	std::string const& _contractName,
-	std::map<std::string, Address> const& _libraryAddresses
+	std::map<std::string, Address> const& _libraryAddresses,
+	std::optional<std::string> const& _mainSourceName
 )
 {
+	using Sources = std::map<std::string, input::Source>;
+
 	if (_mainSourceName.has_value())
 		solAssert(_sourceCode.find(_mainSourceName.value()) != _sourceCode.end(), "");
 
-	m_compiler.reset();
-	m_compiler.setSources(withPreamble(
+	auto sourceContents = withPreamble(
 		_sourceCode,
 		solidity::test::CommonOptions::get().useABIEncoderV1 // _addAbicoderV1Pragma
-	));
-	m_compiler.setLibraries(_libraryAddresses);
-	m_compiler.setRevertStringBehaviour(m_revertStrings);
-	m_compiler.setEVMVersion(m_evmVersion);
-	m_compiler.setOptimiserSettings(m_optimiserSettings);
-	m_compiler.setViaIR(m_compileViaYul);
-	m_compiler.setViaSSACFG(m_compileViaSSACFG);
-	m_compiler.setRevertStringBehaviour(m_revertStrings);
-	if (!m_appendCBORMetadata) {
-		m_compiler.setMetadataFormat(CompilerStack::MetadataFormat::NoMetadata);
-	}
-	m_compiler.setMetadataHash(m_metadataHash);
+	);
+	auto sources = sourceContents | ranges::views::transform([&](auto const& source) {
+		return std::pair{source.first, input::Source{.content = source.second}};
+	}) | ranges::to<Sources>();
+	auto libraries = sources | ranges::views::transform([&](auto const& source) {
+		return std::pair{source.first, convertLibraryAddresses(_libraryAddresses)};
+	}) | ranges::to<input::LibraryAddresses>();
 
-	if (!m_compiler.compile())
+	m_compilerInput.sources = sources;
+	if (!m_compilerInput.settings)
+		m_compilerInput.settings = Settings{};
+	// Auto-enable experimental mode if required but not set by the framework (e.g. `SolidityEndToEndTests`).
+	if (!m_compilerInput.settings->experimental.has_value() && m_evmVersion.isExperimental())
+		m_compilerInput.settings->experimental = true;
+	m_compilerInput.settings->optimizer = buildOptimizerSettings(m_optimiserSettings);
+	m_compilerInput.settings->evmVersion = m_evmVersion;
+	m_compilerInput.settings->viaIR = m_compileViaYul;
+	m_compilerInput.settings->viaSSACFG = m_compileViaSSACFG;
+	m_compilerInput.settings->debug = Debug{
+		.revertStrings = m_revertStrings
+	};
+	m_compilerInput.settings->metadata = buildMetadataSettings(m_appendCBORMetadata, m_metadataHash);
+	m_compilerInput.settings->libraries = libraries;
+	m_compilerInput.settings->outputSelection = OutputSelection{{{"*", {{"*", {
+		"abi",
+		"evm.bytecode.object",
+		"evm.bytecode.linkReferences",
+		"evm.methodIdentifiers",
+		"evm.gasEstimates",
+		"metadata"
+	}}}}}};
+	StandardJSONOutputExt const& output = m_compiler.compile(m_compilerInput);
+
+	if (!output.success())
 	{
-		// The testing framework expects an exception for
-		// "unimplemented" yul IR generation.
-		if (m_compileViaYul)
-			for (auto const& error: m_compiler.errors())
-				if (error->type() == langutil::Error::Type::CodeGenerationError)
-					BOOST_THROW_EXCEPTION(*error);
-		langutil::SourceReferenceFormatter{std::cerr, m_compiler, true, false}
-			.printErrorInformation(m_compiler.errors());
+		// The testing framework expects an exception for "unimplemented" yul IR generation.
+		auto codeGenError = ranges::find_if(output.errors(), [](auto const& e) {
+			return e.type == langutil::Error::Type::CodeGenerationError;
+		});
+
+		if (m_compileViaYul && codeGenError != output.errors().end())
+			BOOST_THROW_EXCEPTION(*convertError(*codeGenError));
+
+		auto errors = output.errors() | ranges::views::transform(convertError) | ranges::to<langutil::ErrorList>();
+		for (auto const& [name, code]: m_compilerInput.sources)
+			fmt::print("\n{}\n", SourceReferenceFormatter::formatErrorInformation(
+				errors,
+				SingletonCharStreamProvider{CharStream{code.content.value_or(""), name}},
+				true,
+				false
+			));
+
 		BOOST_ERROR("Compiling contract failed");
 	}
 
-	if (_contractName.empty())
-		solAssert(m_compiler.contractNames().size() == 1, "Empty contract names only allowed for sources with single contract definitions");
+	// Construct `ContractName` with the contract name given, and use `_mainSourceName`
+	// if the contract's name source prefix is empty. If the contract name is empty, we allow
+	// the output to only define a single contract that does not need to be looked up by name.
+	auto const [sourceName, contractName, _] = decomposeContractName(_contractName);
+	ContractName lookupName{
+		sourceName.empty() ? _mainSourceName.value_or("") : sourceName,
+		contractName
+	};
 
-	std::string contractName(_contractName.empty() ? m_compiler.lastContractName(_mainSourceName) : _contractName);
-	evmasm::LinkerObject obj = m_compiler.object(contractName);
-	BOOST_REQUIRE(obj.linkReferences.empty());
+	auto const* contract = output.contract(lookupName);
+	soltestAssert(contract);
+	soltestAssert(contract->evm.bytecode.linkReferences.empty());
+
 	if (m_showMetadata)
-		std::cout << "metadata: " << m_compiler.metadata(contractName) << std::endl;
-	return obj.bytecode;
+		std::cout << "metadata: " << contract->metadata << std::endl;
+
+	return contract->evm.bytecode.object;
 }
 
 bytes SolidityExecutionFramework::compileContract(
@@ -99,8 +198,8 @@ bytes SolidityExecutionFramework::compileContract(
 {
 	return multiSourceCompileContract(
 		{{"", _sourceCode}},
-		std::nullopt,
 		_contractName,
-		_libraryAddresses
+		_libraryAddresses,
+		std::nullopt
 	);
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -47,9 +47,9 @@ public:
 	SolidityExecutionFramework():
 		m_showMetadata(CommonOptions::get().showMetadata)
 	{
-		auto externalCompiler = CommonOptions::get().solcPath;
-		if (externalCompiler)
-			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>{*externalCompiler};
+		auto solcPath = CommonOptions::get().solcPath;
+		if (solcPath)
+			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>::ipc(*solcPath);
 	}
 
 	explicit SolidityExecutionFramework(
@@ -61,9 +61,9 @@ public:
 		m_showMetadata(CommonOptions::get().showMetadata),
 		m_appendCBORMetadata(_appendCBORMetadata)
 	{
-		auto externalCompiler = CommonOptions::get().solcPath;
-		if (externalCompiler)
-			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>{*externalCompiler};
+		auto solcPath = CommonOptions::get().solcPath;
+		if (solcPath)
+			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>::ipc(*solcPath);
 	}
 
 	bytes const& compileAndRunWithoutCheck(
@@ -95,7 +95,7 @@ public:
 
 protected:
 	StandardJSONInput m_compilerInput;
-	StandardJSONCompiler<StandardJSONOutputExt> m_compiler;
+	StandardJSONCompiler<StandardJSONOutputExt> m_compiler = StandardJSONCompiler<StandardJSONOutputExt>::internal();
 	bool m_compileViaYul = false;
 	bool m_compileViaSSACFG = false;
 	bool m_showMetadata = false;

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -44,7 +44,14 @@ class SolidityExecutionFramework: public ExecutionFramework
 {
 
 public:
-	SolidityExecutionFramework(): m_showMetadata(CommonOptions::get().showMetadata) {}
+	SolidityExecutionFramework():
+		m_showMetadata(CommonOptions::get().showMetadata)
+	{
+		auto externalCompiler = CommonOptions::get().solcPath;
+		if (externalCompiler)
+			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>{*externalCompiler};
+	}
+
 	explicit SolidityExecutionFramework(
 		langutil::EVMVersion _evmVersion,
 		std::vector<boost::filesystem::path> const& _vmPaths,
@@ -53,7 +60,11 @@ public:
 		ExecutionFramework(_evmVersion, _vmPaths),
 		m_showMetadata(CommonOptions::get().showMetadata),
 		m_appendCBORMetadata(_appendCBORMetadata)
-	{}
+	{
+		auto externalCompiler = CommonOptions::get().solcPath;
+		if (externalCompiler)
+			m_compiler = StandardJSONCompiler<StandardJSONOutputExt>{*externalCompiler};
+	}
 
 	bytes const& compileAndRunWithoutCheck(
 		std::map<std::string, std::string> const& _sourceCode,

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -25,28 +25,33 @@
 
 #include <functional>
 
-#include <test/ExecutionFramework.h>
-
-#include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
-
+#include <libsolidity/interface/StandardJSONInput.h>
 #include <libyul/YulStack.h>
+
+#include <ostream>
+#include <test/ExecutionFramework.h>
+#include <test/libsolidity/util/StandardJSONOutput.h>
+#include <test/libsolidity/util/StandardJSONOutputExt.h>
+#include <test/libsolidity/util/StandardJSONCompiler.h>
 
 namespace solidity::frontend::test
 {
 
-class SolidityExecutionFramework: public solidity::test::ExecutionFramework
+using namespace solidity::test;
+
+class SolidityExecutionFramework: public ExecutionFramework
 {
 
 public:
-	SolidityExecutionFramework(): m_showMetadata(solidity::test::CommonOptions::get().showMetadata) {}
+	SolidityExecutionFramework(): m_showMetadata(CommonOptions::get().showMetadata) {}
 	explicit SolidityExecutionFramework(
 		langutil::EVMVersion _evmVersion,
 		std::vector<boost::filesystem::path> const& _vmPaths,
 		bool _appendCBORMetadata = true
 	):
 		ExecutionFramework(_evmVersion, _vmPaths),
-		m_showMetadata(solidity::test::CommonOptions::get().showMetadata),
+		m_showMetadata(CommonOptions::get().showMetadata),
 		m_appendCBORMetadata(_appendCBORMetadata)
 	{}
 
@@ -55,11 +60,11 @@ public:
 		u256 const& _value = 0,
 		std::string const& _contractName = "",
 		bytes const& _arguments = {},
-		std::map<std::string, solidity::test::Address> const& _libraryAddresses = {},
-		std::optional<std::string> const& _sourceName = std::nullopt
+		std::map<std::string, Address> const& _libraryAddresses = {},
+		std::optional<std::string> const& _mainSourceName = std::nullopt
 	) override
 	{
-		bytes bytecode = multiSourceCompileContract(_sourceCode, _sourceName, _contractName, _libraryAddresses);
+		bytes bytecode = multiSourceCompileContract(_sourceCode, _contractName, _libraryAddresses, _mainSourceName);
 		sendMessage(bytecode, _arguments, true, _value);
 		return m_output;
 	}
@@ -67,19 +72,19 @@ public:
 	bytes compileContract(
 		std::string const& _sourceCode,
 		std::string const& _contractName = "",
-		std::map<std::string, solidity::test::Address> const& _libraryAddresses = {}
+		std::map<std::string, Address> const& _libraryAddresses = {}
 	);
 
 	bytes multiSourceCompileContract(
 		std::map<std::string, std::string> const& _sources,
-		std::optional<std::string> const& _mainSourceName = std::nullopt,
 		std::string const& _contractName = "",
-		std::map<std::string, solidity::test::Address> const& _libraryAddresses = {}
+		std::map<std::string, Address> const& _libraryAddresses = {},
+		std::optional<std::string> const& _mainSourceName = std::nullopt
 	);
 
 protected:
-	using CompilerStack = solidity::frontend::CompilerStack;
-	CompilerStack m_compiler;
+	StandardJSONInput m_compilerInput;
+	StandardJSONCompiler<StandardJSONOutputExt> m_compiler;
 	bool m_compileViaYul = false;
 	bool m_compileViaSSACFG = false;
 	bool m_showMetadata = false;
@@ -89,3 +94,4 @@ protected:
 };
 
 } // end namespaces
+

--- a/test/libsolidity/semanticTests/operators/userDefined/operator_evaluation_order.sol
+++ b/test/libsolidity/semanticTests/operators/userDefined/operator_evaluation_order.sol
@@ -74,10 +74,10 @@ contract C {
 // testOperatorsNestedInCalls() ->
 // ~ emit Wrapped(uint256): 0x00
 // ~ emit Wrapped(uint256): 0x01
-// ~ emit Probe(bool): 0x00
+// ~ emit Probe(bool): false
 // ~ emit Wrapped(uint256): 0x02
 // ~ emit Wrapped(uint256): 0x03
-// ~ emit Probe(bool): 0x00
+// ~ emit Probe(bool): false
 // ~ emit Wrapped(uint256): 0x04
 // ~ emit Wrapped(uint256): 0x05
-// ~ emit Probe(bool): 0x00
+// ~ emit Probe(bool): false

--- a/test/libsolidity/util/ContractABIUtils.cpp
+++ b/test/libsolidity/util/ContractABIUtils.cpp
@@ -16,8 +16,8 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
+#include "libsolidity/codegen/ABIFunctions.h"
 #include <test/libsolidity/util/ContractABIUtils.h>
-
 #include <test/libsolidity/util/SoltestErrors.h>
 
 #include <libsolidity/ast/Types.h>
@@ -36,6 +36,7 @@
 #include <numeric>
 #include <regex>
 #include <stdexcept>
+#include <variant>
 
 using namespace solidity;
 using namespace solidity::util;
@@ -140,86 +141,72 @@ std::optional<ABIType> isFixedPoint(std::string const& type)
 	return fixedPointType;
 }
 
-std::string functionSignatureFromABI(Json const& _functionABI)
-{
-	soltestAssert(_functionABI.contains("name"));
-
-	auto inputs = _functionABI["inputs"];
-	std::string signature = {_functionABI["name"].get<std::string>() + "("};
-	size_t parameterCount = 0;
-
-	for (auto const& input: inputs)
-	{
-		parameterCount++;
-		signature += input["type"].get<std::string>();
-		if (parameterCount < inputs.size())
-			signature += ",";
-	}
-
-	return signature + ")";
 }
 
-}
-
-std::optional<solidity::frontend::test::ParameterList> ContractABIUtils::parametersFromJsonOutputs(
+std::optional<solidity::frontend::test::ParameterList> ContractABIUtils::parametersFromABI(
 	ErrorReporter& _errorReporter,
-	Json const& _contractABI,
+	output::ABI const& _contractABI,
 	std::string const& _functionSignature
 )
 {
 	if (_contractABI.empty())
 		return std::nullopt;
 
-	for (auto const& function: _contractABI)
+	for (auto const& entry: _contractABI)
 		// ABI may contain functions without names (constructor, fallback, receive). Since name is
 		// necessary to calculate the signature, these cannot possibly match and can be safely ignored.
-		if (function.contains("name") && _functionSignature == functionSignatureFromABI(function))
+		if (auto* function = std::get_if<output::ABIFunction>(&entry))
 		{
-			ParameterList inplaceTypeParams;
-			ParameterList dynamicTypeParams;
-			ParameterList finalParams;
-
-			for (auto const& output: function["outputs"])
+			if (_functionSignature == formatSignature(*function))
 			{
-				std::string type = output["type"].get<std::string>();
+				ParameterList inplaceTypeParams;
+				ParameterList dynamicTypeParams;
+				ParameterList finalParams;
 
-				ABITypes inplaceTypes;
-				ABITypes dynamicTypes;
-
-				if (appendTypesFromName(output, inplaceTypes, dynamicTypes))
+				for (auto const& output: function->outputs)
 				{
-					for (auto const& type: inplaceTypes)
-						inplaceTypeParams.push_back(Parameter{bytes(), "", type, FormatInfo{}});
-					for (auto const& type: dynamicTypes)
-						dynamicTypeParams.push_back(Parameter{bytes(), "", type, FormatInfo{}});
-				}
-				else
-				{
-					_errorReporter.warning(
-						"Could not convert \"" + type +
-						"\" to internal ABI type representation. Falling back to default encoding."
-					);
-					return std::nullopt;
-				}
+					std::string type = output.type;
 
-				finalParams += inplaceTypeParams;
+					ABITypes inplaceTypes;
+					ABITypes dynamicTypes;
 
-				inplaceTypeParams.clear();
+					if (appendTypesFromName(output, inplaceTypes, dynamicTypes))
+					{
+						for (auto const& type: inplaceTypes)
+							inplaceTypeParams.push_back(Parameter{bytes(), "", type, FormatInfo{}});
+						for (auto const& type: dynamicTypes)
+							dynamicTypeParams.push_back(Parameter{bytes(), "", type, FormatInfo{}});
+					}
+					else
+					{
+						_errorReporter.warning(
+							"Could not convert \"" + type +
+							"\" to internal ABI type representation. Falling back to default encoding."
+						);
+						return std::nullopt;
+					}
+
+					finalParams += inplaceTypeParams;
+
+					inplaceTypeParams.clear();
+				}
+				return std::optional<ParameterList>(finalParams + dynamicTypeParams);
+
 			}
-			return std::optional<ParameterList>(finalParams + dynamicTypeParams);
+
 		}
 
 	return std::nullopt;
 }
 
 bool ContractABIUtils::appendTypesFromName(
-	Json const& _functionOutput,
+	output::ABIParameter const& _functionOutput,
 	ABITypes& _inplaceTypes,
 	ABITypes& _dynamicTypes,
 	bool _isCompoundType
 )
 {
-	std::string type = _functionOutput["type"].get<std::string>();
+	std::string type = _functionOutput.type;
 	if (isBool(type))
 		_inplaceTypes.push_back(ABIType{ABIType::Boolean});
 	else if (isUint(type))
@@ -240,10 +227,12 @@ bool ContractABIUtils::appendTypesFromName(
 	}
 	else if (isTuple(type))
 	{
+		soltestAssert(_functionOutput.components, "Tuple types must define components.");
+
 		ABITypes inplaceTypes;
 		ABITypes dynamicTypes;
 
-		for (auto const& component: _functionOutput["components"])
+		for (auto const& component: *_functionOutput.components)
 			appendTypesFromName(component, inplaceTypes, dynamicTypes, true);
 		_dynamicTypes += inplaceTypes + dynamicTypes;
 	}

--- a/test/libsolidity/util/ContractABIUtils.h
+++ b/test/libsolidity/util/ContractABIUtils.h
@@ -14,17 +14,105 @@
 
 #pragma once
 
+#include <test/libsolidity/util/BytesUtils.h>
+#include <test/libsolidity/util/StandardJSONOutput.h>
 #include <test/libsolidity/util/SoltestTypes.h>
-
 #include <test/libsolidity/util/SoltestErrors.h>
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/JSON.h>
 
+#include <boost/algorithm/string.hpp>
+
 namespace solidity::frontend::test
 {
 
 using ABITypes = std::vector<ABIType>;
+
+inline std::string formatInputType(output::ABIParameter const& _input)
+{
+	if (_input.type == "tuple")
+	{
+		soltestAssert(_input.components, "key \"components\" is not allowed to be empty for tuples");
+		auto types = _input.components.value() | ranges::views::transform([&](auto const& input) {
+			return formatInputType(input);
+		}) | ranges::to<strings>;
+		return "(" + boost::algorithm::join(types, ",") + ")";
+	}
+	return _input.type;
+}
+
+inline strings formatInputTypes(output::ABIFunction const& _function, bool _indexed)
+{
+	return _function.inputs | ranges::views::filter([&](auto const& input) {
+		return input.indexed == _indexed;
+	}) | ranges::views::transform([&](auto const& input) {
+		return formatInputType(input);
+	}) | ranges::to<strings>();
+}
+
+inline strings formatInputTypes(output::ABIEvent const& _event, bool _indexed)
+{
+	return _event.inputs | ranges::views::filter([&](auto const& input) {
+		return input.indexed == _indexed;
+	}) | ranges::views::transform([&](auto const& input) {
+		return formatInputType(input);
+	}) | ranges::to<strings>();
+}
+
+
+inline std::string formatSignature(output::ABIFunction const& _function)
+{
+	auto signatureTypes = _function.inputs | ranges::views::transform([&](auto const& input) {
+		return formatInputType(input);
+	}) | ranges::to<strings>;
+	return _function.name + "(" + boost::algorithm::join(signatureTypes, ",") + ")";
+}
+
+inline std::string formatSignature(output::ABIEvent const& _event)
+{
+	auto signatureTypes = _event.inputs | ranges::views::transform([&](auto const& input) {
+		return formatInputType(input);
+	}) | ranges::to<strings>;
+	return _event.name + "(" + boost::algorithm::join(signatureTypes, ",") + ")";
+}
+
+inline std::string formatEventParameter(output::ABIEvent const* _event, bool _indexed, size_t _index, bytes const& _data)
+{
+	auto isPrintableASCII = [](bytes const& s)
+	{
+		bool zeroes = true;
+		for (auto c: s)
+		{
+			if (static_cast<unsigned>(c) != 0x00)
+			{
+				zeroes = false;
+				if (static_cast<unsigned>(c) <= 0x1f || static_cast<unsigned>(c) >= 0x7f)
+					return false;
+			} else
+				break;
+		}
+		return !zeroes;
+	};
+
+	ABIType abiType(ABIType::Type::Hex);
+	if (isPrintableASCII(_data))
+		abiType = ABIType(ABIType::Type::String);
+	if (_event)
+	{
+		auto indexedTypes = formatInputTypes(*_event, true);
+		auto nonIndexedTypes = formatInputTypes(*_event, false);
+		auto const& types = _indexed ? indexedTypes : nonIndexedTypes;
+		if (_index < types.size())
+		{
+			if (types.at(_index) == "bool")
+				abiType = ABIType(ABIType::Type::Boolean);
+		}
+	}
+	return BytesUtils::formatBytes(_data, abiType);
+}
+
+
 
 /**
  * Utility class that aids conversions from contract ABI types stored in a
@@ -37,9 +125,9 @@ public:
 	/// a list of internal type representations of isoltest.
 	/// Creates parameters from Contract ABI and is used to generate values for
 	/// auto-correction during interactive update routine.
-	static std::optional<ParameterList> parametersFromJsonOutputs(
+	static std::optional<ParameterList> parametersFromABI(
 		ErrorReporter& _errorReporter,
-		Json const& _contractABI,
+		output::ABI const& _contractABI,
 		std::string const& _functionSignature
 	);
 
@@ -75,7 +163,7 @@ public:
 	static size_t encodingSize(ParameterList const& _parameters);
 
 private:
-	/// Parses and translates a single type and returns a list of
+	/// Translates a single type and returns a list of
 	/// internal type representations of isoltest.
 	/// Types defined by the ABI will translate to ABITypes
 	/// as follows:
@@ -85,7 +173,7 @@ private:
 	/// `bytes` -> [`Unsigned`, `Unsigned`, `HexString`]
 	/// ...
 	static bool appendTypesFromName(
-		Json const& _functionOutput,
+		output::ABIParameter const& _functionOutput,
 		ABITypes& _inplaceTypes,
 		ABITypes& _dynamicTypes,
 		bool _isCompoundType = false

--- a/test/libsolidity/util/StandardJSONCompiler.h
+++ b/test/libsolidity/util/StandardJSONCompiler.h
@@ -45,6 +45,11 @@ template<StandardJSONOutputType Output = StandardJSONOutput>
 class StandardJSONCompiler
 {
 public:
+	StandardJSONCompiler() = default;
+	explicit StandardJSONCompiler(boost::filesystem::path _externalCompiler):
+		m_externalCompiler(_externalCompiler)
+	{}
+
 	/// Takes the current compiler input, requests the compiler under test to compile
 	/// and stores its output.
 	/// @returns the stored output
@@ -55,8 +60,10 @@ public:
 	Output const& output() const;
 
 private:
-	/// Last generated output. Will be none before initial compilation.
-	std::optional<Output> m_output;
+	/// If a path is set, this instance will try to call the external compiler via IPC.
+	std::optional<boost::filesystem::path> m_externalCompiler;
+    /// Last generated output. Will be none before initial compilation.
+    std::optional<Output> m_output;
 };
 
 template<StandardJSONOutputType Output>

--- a/test/libsolidity/util/StandardJSONCompiler.h
+++ b/test/libsolidity/util/StandardJSONCompiler.h
@@ -18,16 +18,15 @@
 
 #pragma once
 
+#include <test/libsolidity/util/StandardJSONCompilerAdapter.h>
 #include <test/libsolidity/util/StandardJSONOutput.h>
-#include <test/libsolidity/util/StandardJSONOutputParser.h>
 
 #include <liblangutil/Exceptions.h>
-
-#include <libsolutil/JSON.h>
-#include <libsolidity/interface/StandardCompiler.h>
 #include <libsolidity/interface/StandardJSONInput.h>
+#include <libsolidity/util/SoltestErrors.h>
 
 #include <optional>
+#include <variant>
 
 namespace solidity::frontend::test
 {
@@ -40,48 +39,60 @@ concept StandardJSONOutputType = std::constructible_from<T, StandardJSONOutput>;
 
 /**
  * Provides an interface to the compiler under test.
+ *
+ * Delegates to either an InternalCompilerAdapter (in-process) or an ExternalCompilerAdapter
+ * (external solc binary) depending on how it was constructed.
  */
 template<StandardJSONOutputType Output = StandardJSONOutput>
 class StandardJSONCompiler
 {
 public:
-	StandardJSONCompiler() = default;
-	explicit StandardJSONCompiler(boost::filesystem::path _externalCompiler):
-		m_externalCompiler(_externalCompiler)
-	{}
+	/// Creates a compiler that uses the in-process InternalCompilerAdapter.
+	static StandardJSONCompiler internal()
+	{
+		return StandardJSONCompiler{InternalCompilerAdapter{}};
+	}
+
+	/// Creates a compiler that uses the ExternalCompilerAdapter with the given path to solc.
+	static StandardJSONCompiler ipc([[maybe_unused]] boost::filesystem::path _compilerPath)
+	{
+		#ifdef _WIN32 // windows
+			solUnimplemented("Using external compilers is not supported on Windows.");
+		#else // unix
+			return StandardJSONCompiler{ExternalCompilerAdapter{std::move(_compilerPath)}};
+		#endif
+	}
 
 	/// Takes the current compiler input, requests the compiler under test to compile
 	/// and stores its output.
 	/// @returns the stored output
 	/// @param _input to pass to the compiler
-	Output const& compile(StandardJSONInput const& _input);
+	Output const& compile(StandardJSONInput const& _input)
+	{
+		m_output.emplace(Output{std::visit([&_input](auto& compiler) {
+			return compiler.compile(_input);
+		}, m_compiler)});
+		return this->output();
+	}
 
 	/// @returns the stored output generated during previous compilation.
-	Output const& output() const;
+	Output const& output() const
+	{
+		soltestAssert(m_output.has_value(), "No output found. Please compile first.");
+		return m_output.value();
+	}
 
 private:
-	/// If a path is set, this instance will try to call the external compiler via IPC.
-	std::optional<boost::filesystem::path> m_externalCompiler;
-    /// Last generated output. Will be none before initial compilation.
-    std::optional<Output> m_output;
+	explicit StandardJSONCompiler(InternalCompilerAdapter _adapter):
+		m_compiler(std::move(_adapter))
+	{}
+
+	explicit StandardJSONCompiler(ExternalCompilerAdapter _adapter):
+		m_compiler(std::move(_adapter))
+	{}
+
+	std::variant<InternalCompilerAdapter, ExternalCompilerAdapter> m_compiler;
+	std::optional<Output> m_output;
 };
-
-template<StandardJSONOutputType Output>
-Output const& StandardJSONCompiler<Output>::compile(StandardJSONInput const& _input)
-{
-	Json input = _input;
-	auto json = StandardCompiler{}.compile(input);
-	auto deserialized = json.get<StandardJSONOutput>();
-	m_output.emplace(Output{std::move(deserialized)});
-
-	return this->output();
-}
-
-template<StandardJSONOutputType Output>
-Output const& StandardJSONCompiler<Output>::output() const
-{
-	solAssert(m_output.has_value(), "No output found. Please compile first.");
-	return m_output.value();
-}
 
 }

--- a/test/libsolidity/util/StandardJSONCompilerAdapter.h
+++ b/test/libsolidity/util/StandardJSONCompilerAdapter.h
@@ -1,0 +1,165 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <test/libsolidity/util/StandardJSONOutput.h>
+#include <test/libsolidity/util/StandardJSONOutputParser.h>
+
+#include <libsolidity/interface/StandardCompiler.h>
+#include <libsolidity/interface/StandardJSONInput.h>
+#include <libsolidity/util/SoltestErrors.h>
+
+#include <libsolutil/JSON.h>
+
+#include <boost/asio.hpp>
+#include <boost/process/v2.hpp>
+#include <boost/process/v2/process.hpp>
+#include <boost/process/v2/stdio.hpp>
+
+#include <chrono>
+#include <string>
+
+namespace solidity::frontend::test
+{
+
+using namespace solidity::frontend::input;
+using namespace output;
+
+/**
+ * Adapter that delegates compilation to the in-process StandardCompiler.
+ */
+class InternalCompilerAdapter
+{
+public:
+	InternalCompilerAdapter() = default;
+
+	/// Compiles the given input using the in-process StandardCompiler and
+	/// @returns the deserialized StandardJSONOutput.
+	StandardJSONOutput compile(StandardJSONInput const& _input)
+	{
+		Json jsonInput = _input;
+		Json jsonOutput = StandardCompiler{}.compile(jsonInput);
+		return jsonOutput.get<StandardJSONOutput>();
+	}
+};
+
+/**
+ * Adapter that delegates compilation to a solc-compatible binary via an external process.
+ */
+class ExternalCompilerAdapter
+{
+public:
+	explicit ExternalCompilerAdapter(
+		boost::filesystem::path _path,
+		std::chrono::seconds _timeout = std::chrono::seconds{30}
+	):
+		m_path(std::move(_path)),
+		m_timeout(_timeout)
+	{}
+
+	/// Compiles the given input by spawning an external compiler process and
+	/// communicating via stdin/stdout, then @returns the deserialized StandardJSONOutput.
+	StandardJSONOutput compile(StandardJSONInput const& _input)
+	{
+		namespace bp = boost::process::v2;
+		namespace asio = boost::asio;
+
+		auto ioCtx = asio::io_context{};
+		auto stdinPipe = asio::writable_pipe{ioCtx};
+		auto stdoutPipe = asio::readable_pipe{ioCtx};
+
+		auto spawn = [&]() -> bp::process
+		{
+			auto child = bp::process{
+				ioCtx,
+				m_path,
+				{"--standard-json"},
+				bp::process_stdio{stdinPipe, stdoutPipe, {}}
+			};
+			soltestAssert(child.running(), "Failed to launch the external compiler '" + m_path.string() + "'.");
+			return child;
+		};
+
+		auto write = [&](auto& _stdinPipe, StandardJSONInput const& _input) -> void
+		{
+			auto error = boost::system::error_code{};
+			Json input = _input;
+			asio::write(_stdinPipe, asio::buffer(input.dump()), error);
+			_stdinPipe.close();
+			soltestAssert(!error, "Error writing to the external compiler's stdin.");
+		};
+
+		auto read = [&](auto& _stdoutPipe, auto& _child) -> std::string
+		{
+			auto output = std::string{};
+			auto error = boost::system::error_code{};
+			auto timer = asio::steady_timer{ioCtx, m_timeout};
+
+			asio::async_read(_stdoutPipe, asio::dynamic_buffer(output),
+				[&error, &timer](auto const& _errorCode, size_t) {
+					error = _errorCode;
+					timer.cancel();
+				}
+			);
+			timer.async_wait([&_child, &timer](auto const& _errorCode) {
+				if (_errorCode != asio::error::operation_aborted)
+				{
+					_child.request_exit();
+					timer.cancel();
+				}
+			});
+			ioCtx.run();
+
+			if (timer.expiry() <= asio::steady_timer::clock_type::now())
+				soltestAssert(false, "External compiler '" + m_path.string() + "' timed out after " + std::to_string(m_timeout.count()) + " seconds.");
+			soltestAssert(!error || error == asio::error::eof, "Error reading from the external compiler's stdout.");
+
+			return output;
+		};
+
+		auto parse = [&](auto& _child, std::string _output) -> StandardJSONOutput
+		{
+			_child.wait();
+			soltestAssert(
+				_child.exit_code() == 0,
+				"External compiler exited unexpectedly with code '" + std::to_string(_child.exit_code()) + "'"
+			);
+
+			while (!_output.empty() && (_output.back() == '\n' || _output.back() == '\r'))
+				_output.pop_back();
+
+			auto parser = output::NlohmannParser{};
+			return output::extract<StandardJSONOutput>(parser, _output);
+		};
+
+		auto solc = spawn();
+		write(stdinPipe, _input);
+		auto output = read(stdoutPipe, solc);
+
+		return parse(solc, std::move(output));
+	}
+
+private:
+	/// Path to the binary that complies to solc's standard JSON input / output behaviour.
+	boost::filesystem::path m_path;
+	/// Maximum time to wait for the external compiler to respond.
+	std::chrono::seconds m_timeout;
+};
+
+}

--- a/test/libsolidity/util/StandardJSONOutputExt.cpp
+++ b/test/libsolidity/util/StandardJSONOutputExt.cpp
@@ -32,10 +32,12 @@ std::vector<Error> const& StandardJSONOutputExt::errors() const
 
 std::vector<Contract const*> const StandardJSONOutputExt::contracts() const
 {
-	return m_base.contracts | ranges::views::values | ranges::views::transform([](auto& inner) {
-		return inner | ranges::views::values;
-	}) | ranges::views::join | ranges::views::transform([](auto& c) {
-		return &c;
+	auto sourceUnits = m_base.contracts | ranges::views::values;
+	auto contracts = sourceUnits | ranges::views::transform([](auto& contracts) {
+		return contracts | ranges::views::values;
+	}) | ranges::views::join;
+	return contracts | ranges::views::transform([](Contract const& contract) {
+		return &contract;
 	}) | ranges::to<std::vector<Contract const*>>();
 }
 

--- a/test/libsolidity/util/StandardJSONOutputExt.h
+++ b/test/libsolidity/util/StandardJSONOutputExt.h
@@ -21,7 +21,6 @@
 #include <test/libsolidity/util/Common.h>
 #include <test/libsolidity/util/StandardJSONOutput.h>
 
-#include <optional>
 #include <vector>
 
 namespace solidity::frontend::test
@@ -29,31 +28,34 @@ namespace solidity::frontend::test
 
 using namespace output;
 
+/**
+ * Wraps a StandardJSONOutput with convenience accessors for the test framework.
+ */
 class StandardJSONOutputExt
 {
 public:
-	///
 	explicit StandardJSONOutputExt(StandardJSONOutput _base):
 		m_base(std::move(_base))
 	{}
 
-	///
+	/// @returns true if no errors or only warnings/info messages were produced.
 	bool success() const;
 
-	///
+	/// @returns all errors (including warnings and infos) from the compilation.
 	std::vector<Error> const& errors() const;
 
-	///
+	/// @returns Collected pointers to all contracts across all source units.
 	std::vector<Contract const*> const contracts() const;
 
-	///
+	/// Looks up a contract by its (optionally source-qualified) name.
+	/// If the name is empty, asserts that there is exactly one contract across
+	/// all source units and returns it.
+	/// @returns the contract, or nullptr if not found.
 	Contract const* contract(ContractName const& _contractName = {}) const;
 
 private:
-	///
+	/// The wrapped compiler output.
 	StandardJSONOutput m_base;
-	///
-	mutable std::optional<std::vector<Contract const*>> m_contracts;
 };
 
 }

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -12,6 +12,7 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "libsolidity/util/StandardJSONOutput.h"
 #include <test/libsolidity/util/TestFunctionCall.h>
 
 #include <test/libsolidity/util/BytesUtils.h>
@@ -159,7 +160,7 @@ std::string TestFunctionCall::format(
 						abiParams = ContractABIUtils::failureParameters(output);
 				}
 				else
-					abiParams = ContractABIUtils::parametersFromJsonOutputs(
+					abiParams = ContractABIUtils::parametersFromABI(
 						_errorReporter,
 						m_contractABI,
 						m_call.signature
@@ -252,7 +253,7 @@ std::string TestFunctionCall::formatBytesParameters(
 	}
 	else
 	{
-		std::optional<ParameterList> abiParams = ContractABIUtils::parametersFromJsonOutputs(
+		std::optional<ParameterList> abiParams = ContractABIUtils::parametersFromABI(
 			_errorReporter,
 			m_contractABI,
 			_signature
@@ -413,7 +414,7 @@ void TestFunctionCall::reset()
 {
 	m_rawBytes = bytes{};
 	m_failure = true;
-	m_contractABI = Json();
+	m_contractABI = output::ABI{};
 	m_calledNonExistingFunction = false;
 }
 

--- a/test/libsolidity/util/TestFunctionCall.h
+++ b/test/libsolidity/util/TestFunctionCall.h
@@ -14,8 +14,10 @@
 
 #pragma once
 
+#include "libsolidity/interface/ABI.h"
 #include <test/libsolidity/util/TestFileParser.h>
 #include <test/libsolidity/util/SoltestErrors.h>
+#include <test/libsolidity/util/StandardJSONOutput.h>
 #include <test/libsolidity/util/ContractABIUtils.h>
 
 #include <liblangutil/Exceptions.h>
@@ -97,7 +99,7 @@ public:
 	void setRawBytes(const bytes _rawBytes) { m_rawBytes = _rawBytes; }
 	void setGasCostExcludingCode(std::string const& _runType, u256 const& _gasCost) { m_gasCostsExcludingCode[_runType] = _gasCost; }
 	void setCodeDepositGasCost(std::string const& _runType, u256 const& _gasCost) { m_codeDepositGasCosts[_runType] = _gasCost; }
-	void setContractABI(Json _contractABI) { m_contractABI = std::move(_contractABI); }
+	void setContractABI(output::ABI _contractABI) { m_contractABI = std::move(_contractABI); }
 	void setSideEffects(std::vector<std::string> _sideEffects) { m_call.actualSideEffects = _sideEffects; }
 
 private:
@@ -152,7 +154,7 @@ private:
 	bool m_failure = true;
 	/// JSON object which holds the contract ABI and that is used to set the output formatting
 	/// in the interactive update routine.
-	Json m_contractABI = Json{};
+	output::ABI m_contractABI = output::ABI{};
 	/// Flags that the test failed because the called function is not known to exist on the contract.
 	bool m_calledNonExistingFunction = false;
 };

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(isoltest
 	../libsolidity/util/ContractABIUtils.cpp
 	../libsolidity/util/StandardJSONOutput.h
 	../libsolidity/util/StandardJSONOutputParser.cpp
+	../libsolidity/util/StandardJSONCompilerAdapter.h
 	../libsolidity/util/StandardJSONOutputExt.cpp
 	../libsolidity/util/TestFileParser.cpp
 	../libsolidity/util/TestFunctionCall.cpp


### PR DESCRIPTION
Part of https://github.com/argotorg/solidity/issues/16394. Depends on https://github.com/argotorg/solidity/pull/16588.

## Description

This enables compilation of semantic tests via a standard JSON-compliant, external compiler called via IPC. With this implementation, the external compiler needs to behave like `solc`.

### Usage

Just run `(i)soltest` with `--solc-path <PATH>`.

### Performance considerations

Calling out to an external compiler adds another 50% (compared to the JSON base case) to the run time:

- `soltest` with `CompilerStack`: ~40s
- `soltest` with JSON and `StandardCompiler`: ~46s (+15%)
- `soltest` with JSON and IPC: ~69s (+50%)

## AI Disclosure

- assisted with sketching out the initial inter-process call 
