### PR TITLE
perf: reduce data flow analyzer allocations

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -93,7 +93,7 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 
 void DataFlowAnalyzer::operator()(Assignment& _assignment)
 {
-	std::set<YulName> names;
+	small_flat_set<YulName, 1> names;
 	for (auto const& var: _assignment.variableNames)
 		names.emplace(var.name);
 	assertThrow(_assignment.value, OptimizerException, "");
@@ -104,10 +104,10 @@ void DataFlowAnalyzer::operator()(Assignment& _assignment)
 
 void DataFlowAnalyzer::operator()(VariableDeclaration& _varDecl)
 {
-	std::set<YulName> names;
+	small_flat_set<YulName, 1> names;
 	for (auto const& var: _varDecl.variables)
 		names.emplace(var.name);
-	m_variableScopes.back().variables += names;
+	m_variableScopes.back().variables.insert(names.begin(), names.end());
 
 	if (_varDecl.value)
 	{
@@ -241,7 +241,7 @@ std::optional<YulName> DataFlowAnalyzer::keccakValue(YulName _start, YulName _le
 		return std::nullopt;
 }
 
-void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Expression* _value, bool _isDeclaration)
+void DataFlowAnalyzer::handleAssignment(small_flat_set<YulName, 1> const& _variables, Expression* _value, bool _isDeclaration)
 {
 	if (!_isDeclaration)
 		clearValues(_variables);
@@ -263,7 +263,7 @@ void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Exp
 	}
 
 	auto const& referencedVariables = movableChecker.referencedVariables();
-	std::vector const referencedVariablesSorted(referencedVariables.begin(), referencedVariables.end());
+	small_vector<YulName, 2> const referencedVariablesSorted(referencedVariables.begin(), referencedVariables.end());
 	for (auto const& name: _variables)
 	{
 		m_state.sortedReferences[name] = referencedVariablesSorted;
@@ -316,7 +316,8 @@ void DataFlowAnalyzer::popScope()
 	m_variableScopes.pop_back();
 }
 
-void DataFlowAnalyzer::clearValues(std::set<YulName> const& _variablesToClear)
+template <class VariableSet>
+void DataFlowAnalyzer::clearValues(VariableSet const& _variablesToClear)
 {
 	// All variables that reference variables to be cleared also have to be
 	// cleared, but not recursively, since only the value of the original
@@ -356,7 +357,12 @@ void DataFlowAnalyzer::clearValues(std::set<YulName> const& _variablesToClear)
 			referencingVariablesToClear.emplace(referencingVariable);
 
 	// Clear the value and update the reference relation.
-	for (auto const& name: _variablesToClear + referencingVariablesToClear)
+	for (auto const& name: _variablesToClear)
+	{
+		m_state.value.erase(name);
+		m_state.sortedReferences.erase(name);
+	}
+	for (auto const& name: referencingVariablesToClear)
 	{
 		m_state.value.erase(name);
 		m_state.sortedReferences.erase(name);

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -348,21 +348,18 @@ void DataFlowAnalyzer::clearValues(VariableSet const& _variablesToClear)
 	});
 
 	// Also clear variables that reference variables to be cleared.
-	std::set<YulName> referencingVariablesToClear;
 	std::vector const sortedVariablesToClear(_variablesToClear.begin(), _variablesToClear.end());
-	for (auto const& [referencingVariable, referencedVariables]: m_state.sortedReferences)
+	boost::unordered::erase_if(m_state.sortedReferences, mapTuple([&](auto&& referencingVariable, auto&& referencedVariables) {
 		// instead of checking each variable in `referencedVariables`, we check if there is any intersection making use of the
 		// sortedness of the vectors, which can increase performance by up to 50% in pathological cases
-		if (hasNonemptyIntersectionSorted(referencedVariables, sortedVariablesToClear))
-			referencingVariablesToClear.emplace(referencingVariable);
+		if (!hasNonemptyIntersectionSorted(referencedVariables, sortedVariablesToClear))
+			return false;
+		m_state.value.erase(referencingVariable);
+		return true;
+	}));
 
 	// Clear the value and update the reference relation.
 	for (auto const& name: _variablesToClear)
-	{
-		m_state.value.erase(name);
-		m_state.sortedReferences.erase(name);
-	}
-	for (auto const& name: referencingVariablesToClear)
 	{
 		m_state.value.erase(name);
 		m_state.sortedReferences.erase(name);

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -32,11 +32,17 @@
 #include <libsolutil/Numeric.h>
 #include <libsolutil/Common.h>
 
+#include <boost/container/flat_set.hpp>
+#include <boost/container/small_vector.hpp>
+
 #include <map>
 #include <set>
 
 namespace solidity::yul
 {
+using boost::container::small_flat_set;
+using boost::container::small_vector;
+
 class Dialect;
 struct SideEffects;
 class KnowledgeBase;
@@ -104,7 +110,7 @@ public:
 
 	/// @returns the current value of the given variable, if known - always movable.
 	AssignedValue const* variableValue(YulName _variable) const { return util::valueOrNullptr(m_state.value, _variable); }
-	std::vector<YulName> const* sortedReferences(YulName _variable) const { return util::valueOrNullptr(m_state.sortedReferences, _variable); }
+	small_vector<YulName, 2> const* sortedReferences(YulName _variable) const { return util::valueOrNullptr(m_state.sortedReferences, _variable); }
 	std::map<YulName, AssignedValue> const& allValues() const { return m_state.value; }
 	std::optional<YulName> storageValue(YulName _key) const;
 	std::optional<YulName> memoryValue(YulName _key) const;
@@ -112,17 +118,13 @@ public:
 
 protected:
 	/// Registers the assignment.
-	void handleAssignment(std::set<YulName> const& _names, Expression* _value, bool _isDeclaration);
+	void handleAssignment(small_flat_set<YulName, 1> const& _names, Expression* _value, bool _isDeclaration);
 
 	/// Creates a new inner scope.
 	void pushScope(bool _functionScope);
 
 	/// Removes the innermost scope and clears all variables in it.
 	void popScope();
-
-	/// Clears information about the values assigned to the given variables,
-	/// for example at points where control flow is merged.
-	void clearValues(std::set<YulName> const& _variablesToClear);
 
 	virtual void assignValue(YulName _variable, Expression const* _value);
 
@@ -168,6 +170,11 @@ protected:
 	std::map<FunctionHandle, SideEffects> m_functionSideEffects;
 
 private:
+	/// Clears information about the values assigned to the given variables,
+	/// for example at points where control flow is merged.
+	template <class VariableSet>
+	void clearValues(VariableSet const& _variablesToClear);
+
 	struct Environment
 	{
 		util::unordered_flat_map<YulName, YulName> storage;
@@ -181,7 +188,7 @@ private:
 		std::map<YulName, AssignedValue> value;
 		/// m_references[a].contains(b) <=> the current expression assigned to a references b
 		/// The mapped vectors _must always_ be sorted
-		util::unordered_flat_map<YulName, std::vector<YulName>> sortedReferences;
+		util::unordered_flat_map<YulName, small_vector<YulName, 2>> sortedReferences;
 
 		Environment environment;
 	};
@@ -213,7 +220,7 @@ protected:
 	struct Scope
 	{
 		explicit Scope(bool _isFunction): isFunction(_isFunction) {}
-		std::set<YulName> variables;
+		util::unordered_flat_set<YulName> variables;
 		bool isFunction;
 	};
 	/// Special expression whose address will be used in m_value.


### PR DESCRIPTION
## Description

As suggested by @msooseth, I'm trying to reduce heap allocations to capture some of the performance gain demonstrated by using mimalloc #16639.

This cuts the total number of heap allocations in a uniswap v4-core compilation by 9% (595.10M -> 539.02M), and shows a decent compile time improvement.

Changes:
- Store assignment targets in `small_flat_set<YulName, 1>`. This avoids allocation for the common single-var assignment case.
- Store scope membership in `unordered_flat_set`. Scope variables are only queried and erased; order is unused.
- Store sorted reference lists in `small_vector<YulName, 2>`. These lists are normally tiny.
- Erase invalidated reference entries during the existing `sortedReferences` scan. Each variable is already a unique map key, so collecting the same keys in a temporary `std::set` isn't necessary.
- `clearValues()` is now generic, so it can accept different set types.


```
Baseline: 0.8.37-ci.2026.8.6+commit.9b2f86be.Linux.g++ n=3
Target:   0.8.37-ci.2026.8.9+commit.d0f8ae9e.Linux.g++ n=3
Values are mean ± sample stddev. Δ% = (target mean - baseline mean) / baseline mean. Negative = improvement (lower is better), positive = regression.
winner = '~noise' unless the gap passes a Welch t-test and |Δ%| ≥ 0.1%.

Benchmark                Pipeline  Metric         Base                   Target                 Δ%      winner
-----------------------  --------  -------------  ---------------------  ---------------------  ------  --------
openzeppelin-5.6.1       evmasm    cpu_time       18.2369s ± 0.0193s     17.8837s ± 0.0116s     -1.94%  TARGET
                                   creation_size  725,287 ± 0            725,287 ± 0            0.0%    tie
                                   cycles         63.2694G ± 77.7217M    61.9734G ± 57.5310M    -2.05%  TARGET
                                   instructions   124.9823G ± 473        122.5785G ± 36         -1.92%  TARGET
                                   peak_rss       1015 ± 0 MiB           1065 ± 0 MiB           +4.99%  BASELINE
                                   runtime_size   650,752 ± 0            650,752 ± 0            0.0%    tie
                                   wall_time      18.3659s ± 0.0175s     18.0129s ± 0.0122s     -1.92%  TARGET

openzeppelin-5.6.1       ir        cpu_time       52.1626s ± 0.0527s     49.8994s ± 0.0380s     -4.34%  TARGET
                                   creation_size  675,405 ± 0            675,405 ± 0            0.0%    tie
                                   cycles         184.5272G ± 174.2462M  176.5699G ± 142.9939M  -4.31%  TARGET
                                   instructions   300.9914G ± 1.1239k    288.3880G ± 162        -4.19%  TARGET
                                   peak_rss       1387 ± 0 MiB           1337 ± 0 MiB           -3.58%  TARGET
                                   runtime_size   598,355 ± 0            598,355 ± 0            0.0%    tie
                                   wall_time      52.4456s ± 0.0532s     50.1734s ± 0.0380s     -4.33%  TARGET

solady-0.1.26            evmasm    cpu_time       25.4536s ± 0.0512s     25.1426s ± 0.0216s     -1.22%  TARGET
                                   creation_size  1,514,791 ± 0          1,514,791 ± 0          0.0%    tie
                                   cycles         87.5712G ± 174.8606M   86.5439G ± 71.3928M    -1.17%  TARGET
                                   instructions   182.2905G ± 222        180.4253G ± 421        -1.02%  TARGET
                                   peak_rss       1813 ± 0 MiB           1812 ± 0 MiB           -0.05%  ~noise
                                   runtime_size   1,480,154 ± 0          1,480,154 ± 0          0.0%    tie
                                   wall_time      25.6441s ± 0.0450s     25.3365s ± 0.0270s     -1.2%   TARGET

solady-0.1.26            ir        cpu_time       132.6701s ± 0.0816s    126.9787s ± 0.0223s    -4.29%  TARGET
                                   creation_size  1,681,895 ± 0          1,681,895 ± 0          0.0%    tie
                                   cycles         471.0342G ± 319.0700M  450.6739G ± 91.3081M   -4.32%  TARGET
                                   instructions   682.6695G ± 73         653.6657G ± 257        -4.25%  TARGET
                                   peak_rss       2785 ± 0 MiB           2788 ± 0 MiB           +0.12%  BASELINE
                                   runtime_size   1,650,497 ± 0          1,650,497 ± 0          0.0%    tie
                                   wall_time      133.3793s ± 0.0978s    127.6427s ± 0.0250s    -4.3%   TARGET

prb-math-4.1.1           evmasm    cpu_time       6.6805s ± 0.0164s      6.6034s ± 0.0110s      -1.15%  TARGET
                                   creation_size  252,039 ± 0            252,039 ± 0            0.0%    tie
                                   cycles         21.4643G ± 67.4157M    21.2436G ± 38.1555M    -1.03%  TARGET
                                   instructions   45.7352G ± 136         45.4747G ± 42          -0.57%  TARGET
                                   peak_rss       1171 ± 0 MiB           1171 ± 0 MiB           -0.01%  ~noise
                                   runtime_size   250,178 ± 0            250,178 ± 0            0.0%    tie
                                   wall_time      6.7311s ± 0.0226s      6.6541s ± 0.0095s      -1.14%  TARGET

prb-math-4.1.1           ir        cpu_time       26.8109s ± 0.0093s     25.4873s ± 0.0075s     -4.94%  TARGET
                                   creation_size  262,432 ± 0            262,432 ± 0            0.0%    tie
                                   cycles         93.2943G ± 37.6994M    88.5989G ± 13.9884M    -5.03%  TARGET
                                   instructions   145.0668G ± 428        138.1907G ± 344        -4.74%  TARGET
                                   peak_rss       1430 ± 0 MiB           1430 ± 0 MiB           0.0%    tie
                                   runtime_size   260,832 ± 0            260,832 ± 0            0.0%    tie
                                   wall_time      26.9518s ± 0.0044s     25.6164s ± 0.0062s     -4.95%  TARGET

forge-std-1.16.1         evmasm    cpu_time       8.0321s ± 0.0103s      7.8235s ± 0.0038s      -2.6%   TARGET
                                   creation_size  394,603 ± 0            394,603 ± 0            0.0%    tie
                                   cycles         27.6142G ± 32.9076M    26.8852G ± 11.9252M    -2.64%  TARGET
                                   instructions   54.8421G ± 248         53.7743G ± 49          -1.95%  TARGET
                                   peak_rss       542 ± 0 MiB            542 ± 0 MiB            +0.07%  ~noise
                                   runtime_size   381,729 ± 0            381,729 ± 0            0.0%    tie
                                   wall_time      8.0877s ± 0.0198s      7.8740s ± 0.0048s      -2.64%  TARGET

forge-std-1.16.1         ir        cpu_time       34.6354s ± 0.0248s     33.1892s ± 0.0278s     -4.18%  TARGET
                                   creation_size  422,073 ± 0            422,073 ± 0            0.0%    tie
                                   cycles         122.7875G ± 90.3700M   117.6417G ± 96.5387M   -4.19%  TARGET
                                   instructions   179.8147G ± 227        172.1688G ± 205        -4.25%  TARGET
                                   peak_rss       758 ± 0 MiB            756 ± 0 MiB            -0.3%   TARGET
                                   runtime_size   406,750 ± 0            406,750 ± 0            0.0%    tie
                                   wall_time      34.8104s ± 0.0177s     33.3579s ± 0.0248s     -4.17%  TARGET

v4-core-4.0.0            evmasm    cpu_time       16.0804s ± 0.0128s     15.7170s ± 0.0066s     -2.26%  TARGET
                                   creation_size  2,012,188 ± 0          2,012,188 ± 0          0.0%    tie
                                   cycles         55.8132G ± 32.3274M    54.5466G ± 20.6950M    -2.27%  TARGET
                                   instructions   110.3795G ± 49         108.2105G ± 681        -1.97%  TARGET
                                   peak_rss       861 ± 0 MiB            863 ± 0 MiB            +0.17%  BASELINE
                                   runtime_size   1,983,262 ± 0          1,983,262 ± 0          0.0%    tie
                                   wall_time      16.1980s ± 0.0133s     15.8314s ± 0.0022s     -2.26%  TARGET

v4-core-4.0.0            ir        cpu_time       89.5287s ± 0.0238s     86.2381s ± 0.0185s     -3.68%  TARGET
                                   creation_size  1,804,635 ± 0          1,804,635 ± 0          0.0%    tie
                                   cycles         318.1867G ± 95.7863M   306.4641G ± 93.1999M   -3.68%  TARGET
                                   instructions   480.9478G ± 1.4668k    464.1012G ± 1.0655k    -3.5%   TARGET
                                   peak_rss       1617 ± 0 MiB           1600 ± 0 MiB           -1.02%  TARGET
                                   runtime_size   1,777,945 ± 0          1,777,945 ± 0          0.0%    tie
                                   wall_time      89.9842s ± 0.0219s     86.6806s ± 0.0220s     -3.67%  TARGET

morpho-blue-1.0.0        evmasm    cpu_time       9.2900s ± 0.0134s      9.1379s ± 0.0018s      -1.64%  TARGET
                                   creation_size  802,290 ± 0            802,290 ± 0            0.0%    tie
                                   cycles         32.2336G ± 50.1880M    31.6951G ± 8.7985M     -1.67%  TARGET
                                   instructions   65.0197G ± 222         63.8944G ± 136         -1.73%  TARGET
                                   peak_rss       542 ± 0 MiB            542 ± 0 MiB            +0.07%  ~noise
                                   runtime_size   798,085 ± 0            798,085 ± 0            0.0%    tie
                                   wall_time      9.3493s ± 0.0125s      9.1947s ± 0.0057s      -1.65%  TARGET

morpho-blue-1.0.0        ir        cpu_time       51.1071s ± 0.0480s     49.2210s ± 0.0175s     -3.69%  TARGET
                                   creation_size  753,526 ± 0            753,526 ± 0            0.0%    tie
                                   cycles         181.6723G ± 178.6852M  174.9592G ± 82.4992M   -3.7%   TARGET
                                   instructions   263.1485G ± 560        251.1688G ± 210        -4.55%  TARGET
                                   peak_rss       875 ± 0 MiB            876 ± 0 MiB            +0.15%  BASELINE
                                   runtime_size   750,240 ± 0            750,240 ± 0            0.0%    tie
                                   wall_time      51.3653s ± 0.0442s     49.4696s ± 0.0180s     -3.69%  TARGET

seaport-1.6              evmasm    cpu_time       108.5253s ± 0.0631s    106.4529s ± 0.1082s    -1.91%  TARGET
                                   creation_size  13,568,823 ± 0         13,568,823 ± 0         0.0%    tie
                                   cycles         376.5852G ± 187.1832M  369.3612G ± 388.8043M  -1.92%  TARGET
                                   instructions   672.5458G ± 3.2772k    660.9146G ± 1.2898k    -1.73%  TARGET
                                   peak_rss       2644 ± 0 MiB           2635 ± 0 MiB           -0.34%  TARGET
                                   runtime_size   12,556,893 ± 0         12,556,893 ± 0         0.0%    tie
                                   wall_time      109.2112s ± 0.0648s    107.1274s ± 0.1118s    -1.91%  TARGET

solmate-6                evmasm    cpu_time       3.5026s ± 0.0027s      3.4336s ± 0.0009s      -1.97%  TARGET
                                   creation_size  279,294 ± 0            279,294 ± 0            0.0%    tie
                                   cycles         12.1756G ± 9.7649M     11.9328G ± 6.8418M     -1.99%  TARGET
                                   instructions   24.8168G ± 181         24.3722G ± 105         -1.79%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   272,389 ± 0            272,389 ± 0            0.0%    tie
                                   wall_time      3.5290s ± 0.0125s      3.4592s ± 0.0079s      -1.98%  TARGET

solmate-6                ir        cpu_time       18.7255s ± 0.0303s     17.9417s ± 0.0129s     -4.19%  TARGET
                                   creation_size  267,193 ± 0            267,193 ± 0            0.0%    tie
                                   cycles         66.5457G ± 106.5130M   63.7495G ± 44.0190M    -4.2%   TARGET
                                   instructions   98.4781G ± 228         94.0704G ± 117         -4.48%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   259,851 ± 0            259,851 ± 0            0.0%    tie
                                   wall_time      18.8164s ± 0.0300s     18.0304s ± 0.0109s     -4.18%  TARGET

solarray-a547630         evmasm    cpu_time       1.0186s ± 0.0025s      1.0122s ± 0.0067s      -0.63%  ~noise
                                   creation_size  4,474 ± 0              4,474 ± 0              0.0%    tie
                                   cycles         3.2251G ± 5.4466M      3.2070G ± 22.4943M     -0.56%  ~noise
                                   instructions   7.6376G ± 23           7.6287G ± 8            -0.12%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   3,992 ± 0              3,992 ± 0              0.0%    tie
                                   wall_time      1.0272s ± 0.0040s      1.0205s ± 0.0057s      -0.65%  ~noise

solarray-a547630         ir        cpu_time       1.1946s ± 0.0029s      1.1917s ± 0.0007s      -0.25%  ~noise
                                   creation_size  4,220 ± 0              4,220 ± 0              0.0%    tie
                                   cycles         3.8556G ± 9.4355M      3.8510G ± 1.6932M      -0.12%  ~noise
                                   instructions   8.7550G ± 32           8.6834G ± 30           -0.82%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   3,920 ± 0              3,920 ± 0              0.0%    tie
                                   wall_time      1.2033s ± 0.0028s      1.2001s ± 0.0009s      -0.27%  ~noise

solidity-verifier        evmasm    cpu_time       0.1060s ± 0.0002s      0.1049s ± 0.0002s      -1.06%  TARGET
                                   creation_size  4,790 ± 0              4,790 ± 0              0.0%    tie
                                   cycles         295.5401M ± 167.5773k  292.1252M ± 48.0605k   -1.16%  TARGET
                                   instructions   635.5532M ± 5          627.6992M ± 8          -1.24%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   4,712 ± 0              4,712 ± 0              0.0%    tie
                                   wall_time      0.1070s ± 0.0002s      0.1058s ± 0.0002s      -1.1%   TARGET

solidity-verifier        ir        cpu_time       0.2218s ± 0.0002s      0.2153s ± 0.0002s      -2.95%  TARGET
                                   creation_size  4,215 ± 0              4,215 ± 0              0.0%    tie
                                   cycles         709.3663M ± 230.6292k  686.0757M ± 575.2861k  -3.28%  TARGET
                                   instructions   1.3577G ± 32           1.3125G ± 26           -3.33%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   4,161 ± 0              4,161 ± 0              0.0%    tie
                                   wall_time      0.2233s ± 0.0004s      0.2167s ± 0.0003s      -2.97%  TARGET

solidity-optimizor-club  ir        cpu_time       1.0816s ± 0.0020s      1.0491s ± 0.0010s      -3.0%   TARGET
                                   creation_size  21,778 ± 0             21,778 ± 0             0.0%    tie
                                   cycles         3.7407G ± 5.2469M      3.6267G ± 2.9133M      -3.05%  TARGET
                                   instructions   7.0230G ± 45           6.8142G ± 35           -2.97%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   20,616 ± 0             20,616 ± 0             0.0%    tie
                                   wall_time      1.0874s ± 0.0019s      1.0548s ± 0.0011s      -2.99%  TARGET

solidity-chains          evmasm    cpu_time       0.1113s ± 0.0002s      0.1082s ± 0.0002s      -2.8%   TARGET
                                   creation_size  5,831 ± 0              5,831 ± 0              0.0%    tie
                                   cycles         317.8958M ± 567.3079k  308.8609M ± 312.4357k  -2.84%  TARGET
                                   instructions   650.1319M ± 11         633.8709M ± 30         -2.5%   TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            0.0%    tie
                                   runtime_size   5,803 ± 0              5,803 ± 0              0.0%    tie
                                   wall_time      0.1121s ± 0.0003s      0.1091s ± 0.0003s      -2.74%  TARGET
```

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [ ] No AI tools were used

gpt 5.6 sol xhigh identified high-impact allocation reductions, determined typical set/vector sizes, tested different inline capacities, and implemented the changes.