### PR TITLE
perf: Skip redundant stack limit analysis

### DIFF
--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -182,7 +182,7 @@ void eliminateVariables(
 	UnusedPruner::runUntilStabilised(_dialect, _ast, _allowMSizeOptimization, nullptr, allFunctions);
 }
 
-void eliminateVariablesOptimizedCodegen(
+bool eliminateVariablesOptimizedCodegen(
 	Dialect const& _dialect,
 	Block& _ast,
 	std::map<YulName, std::vector<StackLayoutGenerator::StackTooDeep>> const& _unreachables,
@@ -190,7 +190,7 @@ void eliminateVariablesOptimizedCodegen(
 )
 {
 	if (std::all_of(_unreachables.begin(), _unreachables.end(), [](auto const& _item) { return _item.second.empty(); }))
-		return;
+		return true;
 
 	RematCandidateSelector selector{_dialect};
 	selector(_ast);
@@ -232,6 +232,7 @@ void eliminateVariablesOptimizedCodegen(
 	// Do not remove functions.
 	std::set<YulName> allFunctions = NameCollector{_ast, NameCollector::OnlyFunctions}.names();
 	UnusedPruner::runUntilStabilised(_dialect, _ast, _allowMSizeOptimization, nullptr, allFunctions);
+	return false;
 }
 
 }
@@ -258,6 +259,7 @@ std::tuple<bool, Block> StackCompressor::run(
 	}
 	bool allowMSizeOptimization = !MSizeFinder::containsMSize(*_object.dialect(), _object.code()->root());
 	Block astRoot = std::get<Block>(ASTCopier{}(_object.code()->root()));
+	bool stackCompressionSuccessful = false;
 	if (usesOptimizedCodeGenerator)
 	{
 		yul::AsmAnalysisInfo analysisInfo = yul::AsmAnalyzer::analyzeStrictAssertCorrect(
@@ -267,7 +269,7 @@ std::tuple<bool, Block> StackCompressor::run(
 		);
 		std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(analysisInfo, *_object.dialect(), astRoot);
 		yulAssert(evmDialect);
-		eliminateVariablesOptimizedCodegen(
+		stackCompressionSuccessful = eliminateVariablesOptimizedCodegen(
 			*_object.dialect(),
 			astRoot,
 			StackLayoutGenerator::reportStackTooDeep(*cfg, *evmDialect),
@@ -291,6 +293,5 @@ std::tuple<bool, Block> StackCompressor::run(
 			);
 		}
 	}
-	return std::make_tuple(false, std::move(astRoot));
+	return std::make_tuple(stackCompressionSuccessful, std::move(astRoot));
 }
-

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -168,16 +168,19 @@ void OptimiserSuite::run(
 		{
 			if (usesOptimizedCodeGenerator)
 			{
+				bool stackCompressionSuccessful = false;
 				{
 					PROFILER_PROBE("StackCompressor", probe);
 					_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
-					astRoot = std::get<1>(StackCompressor::run(
+					auto stackCompressionResult = StackCompressor::run(
 						_object,
 						_optimizeStackAllocation,
 						stackCompressorMaxIterations
-					));
+					);
+					stackCompressionSuccessful = std::get<0>(stackCompressionResult);
+					astRoot = std::move(std::get<1>(stackCompressionResult));
 				}
-				if (evmDialect->providesObjectAccess())
+				if (evmDialect->providesObjectAccess() && !stackCompressionSuccessful)
 				{
 					PROFILER_PROBE("StackLimitEvader", probe);
 					_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));

--- a/test/cmdlineTests/ast_ir/output
+++ b/test/cmdlineTests/ast_ir/output
@@ -637,28 +637,28 @@ Optimized IR AST:
 {
     "code": {
         "block": {
-            "nativeSrc": "51:315:0",
+            "nativeSrc": "51:314:0",
             "nodeType": "YulBlock",
             "src": "-1:-1:0",
             "statements": [
                 {
-                    "nativeSrc": "61:299:0",
+                    "nativeSrc": "61:298:0",
                     "nodeType": "YulBlock",
                     "src": "-1:-1:0",
                     "statements": [
                         {
-                            "nativeSrc": "121:27:0",
+                            "nativeSrc": "121:26:0",
                             "nodeType": "YulVariableDeclaration",
                             "src": "60:13:0",
                             "value": {
                                 "arguments": [
                                     {
                                         "kind": "number",
-                                        "nativeSrc": "143:4:0",
+                                        "nativeSrc": "143:3:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
-                                        "value": "0x80"
+                                        "value": "128"
                                     }
                                 ],
                                 "functionName": {
@@ -667,7 +667,7 @@ Optimized IR AST:
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "131:17:0",
+                                "nativeSrc": "131:16:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
@@ -686,7 +686,7 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "kind": "number",
-                                        "nativeSrc": "168:2:0",
+                                        "nativeSrc": "167:2:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
@@ -694,28 +694,28 @@ Optimized IR AST:
                                     },
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "172:2:0",
+                                        "nativeSrc": "171:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "mstore",
-                                    "nativeSrc": "161:6:0",
+                                    "nativeSrc": "160:6:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "161:14:0",
+                                "nativeSrc": "160:14:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "161:14:0",
+                            "nativeSrc": "160:14:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         },
                         {
                             "body": {
-                                "nativeSrc": "203:16:0",
+                                "nativeSrc": "202:16:0",
                                 "nodeType": "YulBlock",
                                 "src": "60:13:0",
                                 "statements": [
@@ -724,7 +724,7 @@ Optimized IR AST:
                                             "arguments": [
                                                 {
                                                     "kind": "number",
-                                                    "nativeSrc": "212:1:0",
+                                                    "nativeSrc": "211:1:0",
                                                     "nodeType": "YulLiteral",
                                                     "src": "60:13:0",
                                                     "type": "",
@@ -732,7 +732,7 @@ Optimized IR AST:
                                                 },
                                                 {
                                                     "kind": "number",
-                                                    "nativeSrc": "215:1:0",
+                                                    "nativeSrc": "214:1:0",
                                                     "nodeType": "YulLiteral",
                                                     "src": "60:13:0",
                                                     "type": "",
@@ -741,15 +741,15 @@ Optimized IR AST:
                                             ],
                                             "functionName": {
                                                 "name": "revert",
-                                                "nativeSrc": "205:6:0",
+                                                "nativeSrc": "204:6:0",
                                                 "nodeType": "YulIdentifier",
                                                 "src": "60:13:0"
                                             },
-                                            "nativeSrc": "205:12:0",
+                                            "nativeSrc": "204:12:0",
                                             "nodeType": "YulFunctionCall",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "205:12:0",
+                                        "nativeSrc": "204:12:0",
                                         "nodeType": "YulExpressionStatement",
                                         "src": "60:13:0"
                                     }
@@ -759,20 +759,20 @@ Optimized IR AST:
                                 "arguments": [],
                                 "functionName": {
                                     "name": "callvalue",
-                                    "nativeSrc": "191:9:0",
+                                    "nativeSrc": "190:9:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "191:11:0",
+                                "nativeSrc": "190:11:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "188:31:0",
+                            "nativeSrc": "187:31:0",
                             "nodeType": "YulIf",
                             "src": "60:13:0"
                         },
                         {
-                            "nativeSrc": "232:34:0",
+                            "nativeSrc": "231:34:0",
                             "nodeType": "YulVariableDeclaration",
                             "src": "60:13:0",
                             "value": {
@@ -780,7 +780,7 @@ Optimized IR AST:
                                     {
                                         "hexValue": "435f325f6465706c6f796564",
                                         "kind": "string",
-                                        "nativeSrc": "251:14:0",
+                                        "nativeSrc": "250:14:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
@@ -789,18 +789,18 @@ Optimized IR AST:
                                 ],
                                 "functionName": {
                                     "name": "datasize",
-                                    "nativeSrc": "242:8:0",
+                                    "nativeSrc": "241:8:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "242:24:0",
+                                "nativeSrc": "241:24:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
                             "variables": [
                                 {
                                     "name": "_2",
-                                    "nativeSrc": "236:2:0",
+                                    "nativeSrc": "235:2:0",
                                     "nodeType": "YulTypedName",
                                     "src": "60:13:0",
                                     "type": ""
@@ -812,7 +812,7 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "288:2:0",
+                                        "nativeSrc": "287:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     },
@@ -821,7 +821,7 @@ Optimized IR AST:
                                             {
                                                 "hexValue": "435f325f6465706c6f796564",
                                                 "kind": "string",
-                                                "nativeSrc": "303:14:0",
+                                                "nativeSrc": "302:14:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -830,32 +830,32 @@ Optimized IR AST:
                                         ],
                                         "functionName": {
                                             "name": "dataoffset",
-                                            "nativeSrc": "292:10:0",
+                                            "nativeSrc": "291:10:0",
                                             "nodeType": "YulIdentifier",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "292:26:0",
+                                        "nativeSrc": "291:26:0",
                                         "nodeType": "YulFunctionCall",
                                         "src": "60:13:0"
                                     },
                                     {
                                         "name": "_2",
-                                        "nativeSrc": "320:2:0",
+                                        "nativeSrc": "319:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "codecopy",
-                                    "nativeSrc": "279:8:0",
+                                    "nativeSrc": "278:8:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "279:44:0",
+                                "nativeSrc": "278:44:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "279:44:0",
+                            "nativeSrc": "278:44:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         },
@@ -864,28 +864,28 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "343:2:0",
+                                        "nativeSrc": "342:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     },
                                     {
                                         "name": "_2",
-                                        "nativeSrc": "347:2:0",
+                                        "nativeSrc": "346:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "return",
-                                    "nativeSrc": "336:6:0",
+                                    "nativeSrc": "335:6:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "336:14:0",
+                                "nativeSrc": "335:14:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "336:14:0",
+                            "nativeSrc": "335:14:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         }
@@ -901,12 +901,12 @@ Optimized IR AST:
         {
             "code": {
                 "block": {
-                    "nativeSrc": "439:118:0",
+                    "nativeSrc": "438:118:0",
                     "nodeType": "YulBlock",
                     "src": "-1:-1:0",
                     "statements": [
                         {
-                            "nativeSrc": "453:94:0",
+                            "nativeSrc": "452:94:0",
                             "nodeType": "YulBlock",
                             "src": "-1:-1:0",
                             "statements": [
@@ -915,7 +915,7 @@ Optimized IR AST:
                                         "arguments": [
                                             {
                                                 "kind": "number",
-                                                "nativeSrc": "528:1:0",
+                                                "nativeSrc": "527:1:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -923,7 +923,7 @@ Optimized IR AST:
                                             },
                                             {
                                                 "kind": "number",
-                                                "nativeSrc": "531:1:0",
+                                                "nativeSrc": "530:1:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -932,15 +932,15 @@ Optimized IR AST:
                                         ],
                                         "functionName": {
                                             "name": "revert",
-                                            "nativeSrc": "521:6:0",
+                                            "nativeSrc": "520:6:0",
                                             "nodeType": "YulIdentifier",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "521:12:0",
+                                        "nativeSrc": "520:12:0",
                                         "nodeType": "YulFunctionCall",
                                         "src": "60:13:0"
                                     },
-                                    "nativeSrc": "521:12:0",
+                                    "nativeSrc": "520:12:0",
                                     "nodeType": "YulExpressionStatement",
                                     "src": "60:13:0"
                                 }

--- a/test/cmdlineTests/constant_optimizer_yul/output
+++ b/test/cmdlineTests/constant_optimizer_yul/output
@@ -4,7 +4,7 @@ object "C_12" {
     code {
         {
             /// @src 0:61:418  "contract C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             /// @src 0:103:238  "assembly {..."

--- a/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_all/output
+++ b/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_all/output
@@ -168,7 +168,7 @@ object "C_6" {
     code {
         {
             /// @src 0:60:101  "contract C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_6_deployed")

--- a/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_location_only/output
+++ b/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_location_only/output
@@ -167,7 +167,7 @@ object "C_6" {
     code {
         {
             /// @src 0:60:101
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_6_deployed")

--- a/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_none/output
+++ b/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_none/output
@@ -157,7 +157,7 @@ Optimized IR:
 object "C_6" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_6_deployed")

--- a/test/cmdlineTests/debug_info_in_yul_snippet_escaping/output
+++ b/test/cmdlineTests/debug_info_in_yul_snippet_escaping/output
@@ -68,7 +68,7 @@ object "C_2" {
     code {
         {
             /// @src 0:265:278  "contract C {}"
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_2_deployed")
@@ -415,7 +415,7 @@ object "D_27" {
     code {
         {
             /// @src 0:279:599  "contract D /** @src 0:96:165  \"contract D {...\" *\/ {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("D_27_deployed")
@@ -428,7 +428,7 @@ object "D_27" {
         code {
             {
                 /// @src 0:279:599  "contract D /** @src 0:96:165  \"contract D {...\" *\/ {..."
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))
                 {
@@ -504,7 +504,7 @@ object "D_27" {
             code {
                 {
                     /// @src 0:265:278  "contract C {}"
-                    let _1 := memoryguard(0x80)
+                    let _1 := memoryguard(128)
                     mstore(64, _1)
                     if callvalue() { revert(0, 0) }
                     let _2 := datasize("C_2_deployed")

--- a/test/cmdlineTests/ir_compiler_inheritance_nosubobjects/output
+++ b/test/cmdlineTests/ir_compiler_inheritance_nosubobjects/output
@@ -4,7 +4,7 @@ object "C_7" {
     code {
         {
             /// @src 0:82:117  "contract C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_7_deployed")
@@ -30,7 +30,7 @@ object "D_10" {
     code {
         {
             /// @src 0:118:137  "contract D is C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("D_10_deployed")

--- a/test/cmdlineTests/ir_compiler_subobjects/output
+++ b/test/cmdlineTests/ir_compiler_subobjects/output
@@ -4,7 +4,7 @@ object "C_3" {
     code {
         {
             /// @src 0:82:95  "contract C {}"
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_3_deployed")
@@ -30,7 +30,7 @@ object "D_16" {
     code {
         {
             /// @src 0:96:165  "contract D {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("D_16_deployed")
@@ -43,7 +43,7 @@ object "D_16" {
         code {
             {
                 /// @src 0:96:165  "contract D {..."
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))
                 {
@@ -81,7 +81,7 @@ object "D_16" {
             code {
                 {
                     /// @src 0:82:95  "contract C {}"
-                    let _1 := memoryguard(0x80)
+                    let _1 := memoryguard(128)
                     mstore(64, _1)
                     if callvalue() { revert(0, 0) }
                     let _2 := datasize("C_3_deployed")

--- a/test/cmdlineTests/ir_optimized_transient_storage_value_type/output
+++ b/test/cmdlineTests/ir_optimized_transient_storage_value_type/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_14" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_14_deployed")

--- a/test/cmdlineTests/ir_optimized_with_optimize/output
+++ b/test/cmdlineTests/ir_optimized_with_optimize/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_2" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_2_deployed")

--- a/test/cmdlineTests/ir_subobject_order/output
+++ b/test/cmdlineTests/ir_subobject_order/output
@@ -25,7 +25,7 @@ Optimized IR:
 object "C_33" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("A_13")

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
@@ -4,7 +4,7 @@ object "D_8" {
     code {
         {
             /// @src 0:82:166  "contract D {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("D_8_deployed")

--- a/test/cmdlineTests/keccak_optimization_low_runs/output
+++ b/test/cmdlineTests/keccak_optimization_low_runs/output
@@ -4,7 +4,7 @@ object "C_7" {
     code {
         {
             /// @src 0:62:285  "contract C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_7_deployed")

--- a/test/cmdlineTests/mcopy_bytes_array_returned_from_function/output
+++ b/test/cmdlineTests/mcopy_bytes_array_returned_from_function/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_14" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_14_deployed")
@@ -15,7 +15,7 @@ object "C_14" {
     object "C_14_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0xc2985578, shr(224, calldataload(0)))

--- a/test/cmdlineTests/mcopy_string_literal_returned_from_function/output
+++ b/test/cmdlineTests/mcopy_string_literal_returned_from_function/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_10" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_10_deployed")
@@ -15,7 +15,7 @@ object "C_10" {
     object "C_10_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0xc2985578, shr(224, calldataload(0)))

--- a/test/cmdlineTests/name_simplifier/output
+++ b/test/cmdlineTests/name_simplifier/output
@@ -4,7 +4,7 @@ object "C_59" {
     code {
         {
             /// @src 0:346:625  "contract C {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_59_deployed")
@@ -17,7 +17,7 @@ object "C_59" {
         code {
             {
                 /// @src 0:346:625  "contract C {..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0xf8eddcc6, shr(224, calldataload(0)))

--- a/test/cmdlineTests/optimizer_array_sload/output
+++ b/test/cmdlineTests/optimizer_array_sload/output
@@ -4,7 +4,7 @@ object "Arraysum_34" {
     code {
         {
             /// @src 0:80:429  "contract Arraysum {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("Arraysum_34_deployed")
@@ -17,7 +17,7 @@ object "Arraysum_34" {
         code {
             {
                 /// @src 0:80:429  "contract Arraysum {..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0x81d73423, shr(224, calldataload(0)))

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_all/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_all/output.json
@@ -169,7 +169,7 @@ object \"C_6\" {
     code {
         {
             /// @src 0:60:101  \"contract C {...\"
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize(\"C_6_deployed\")

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_location_only/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_location_only/output.json
@@ -168,7 +168,7 @@ object \"C_6\" {
     code {
         {
             /// @src 0:60:101
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize(\"C_6_deployed\")

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_none/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_none/output.json
@@ -158,7 +158,7 @@ object \"C_6\" {
 object \"C_6\" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize(\"C_6_deployed\")

--- a/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
@@ -614,7 +614,7 @@ object \"C_54\" {
     code {
         {
             /// @src 0:79:510  \"contract C...\"
-            let _1 := memoryguard(0xa0)
+            let _1 := memoryguard(160)
             if callvalue() { revert(0, 0) }
             let programSize := datasize(\"C_54\")
             let argSize := sub(codesize(), programSize)
@@ -650,7 +650,7 @@ object \"C_54\" {
         code {
             {
                 /// @src 0:79:510  \"contract C...\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     switch shr(224, calldataload(0))
@@ -1450,7 +1450,7 @@ object \"D_72\" {
     code {
         {
             /// @src 1:91:181  \"contract D is C(3)...\"
-            let _1 := memoryguard(0xa0)
+            let _1 := memoryguard(160)
             if callvalue() { revert(0, 0) }
             let programSize := datasize(\"D_72\")
             let argSize := sub(codesize(), programSize)
@@ -1493,7 +1493,7 @@ object \"D_72\" {
         code {
             {
                 /// @src 1:91:181  \"contract D is C(3)...\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     switch shr(224, calldataload(0))

--- a/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
@@ -5,12 +5,12 @@
                 "irOptimizedAst": {
                     "code": {
                         "block": {
-                            "nativeSrc": "43:639:0",
+                            "nativeSrc": "43:638:0",
                             "nodeType": "YulBlock",
                             "src": "-1:-1:0",
                             "statements": [
                                 {
-                                    "nativeSrc": "53:421:0",
+                                    "nativeSrc": "53:420:0",
                                     "nodeType": "YulBlock",
                                     "src": "-1:-1:0",
                                     "statements": [
@@ -29,11 +29,11 @@
                                                         "arguments": [
                                                             {
                                                                 "kind": "number",
-                                                                "nativeSrc": "136:4:0",
+                                                                "nativeSrc": "136:3:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
-                                                                "value": "0x80"
+                                                                "value": "128"
                                                             }
                                                         ],
                                                         "functionName": {
@@ -42,7 +42,7 @@
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "124:17:0",
+                                                        "nativeSrc": "124:16:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
@@ -53,17 +53,17 @@
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "113:29:0",
+                                                "nativeSrc": "113:28:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "113:29:0",
+                                            "nativeSrc": "113:28:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         },
                                         {
                                             "body": {
-                                                "nativeSrc": "182:111:0",
+                                                "nativeSrc": "181:111:0",
                                                 "nodeType": "YulBlock",
                                                 "src": "56:13:0",
                                                 "statements": [
@@ -72,15 +72,15 @@
                                                             "arguments": [],
                                                             "functionName": {
                                                                 "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
-                                                                "nativeSrc": "200:77:0",
+                                                                "nativeSrc": "199:77:0",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "56:13:0"
                                                             },
-                                                            "nativeSrc": "200:79:0",
+                                                            "nativeSrc": "199:79:0",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "200:79:0",
+                                                        "nativeSrc": "199:79:0",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "56:13:0"
                                                     }
@@ -90,38 +90,38 @@
                                                 "arguments": [],
                                                 "functionName": {
                                                     "name": "callvalue",
-                                                    "nativeSrc": "158:9:0",
+                                                    "nativeSrc": "157:9:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "158:11:0",
+                                                "nativeSrc": "157:11:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "155:138:0",
+                                            "nativeSrc": "154:138:0",
                                             "nodeType": "YulIf",
                                             "src": "56:13:0"
                                         },
                                         {
-                                            "nativeSrc": "306:30:0",
+                                            "nativeSrc": "305:30:0",
                                             "nodeType": "YulVariableDeclaration",
                                             "src": "56:13:0",
                                             "value": {
                                                 "arguments": [],
                                                 "functionName": {
                                                     "name": "allocate_unbounded",
-                                                    "nativeSrc": "316:18:0",
+                                                    "nativeSrc": "315:18:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "316:20:0",
+                                                "nativeSrc": "315:20:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
                                             "variables": [
                                                 {
                                                     "name": "_1",
-                                                    "nativeSrc": "310:2:0",
+                                                    "nativeSrc": "309:2:0",
                                                     "nodeType": "YulTypedName",
                                                     "src": "56:13:0",
                                                     "type": ""
@@ -133,7 +133,7 @@
                                                 "arguments": [
                                                     {
                                                         "name": "_1",
-                                                        "nativeSrc": "358:2:0",
+                                                        "nativeSrc": "357:2:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
@@ -142,7 +142,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "373:14:0",
+                                                                "nativeSrc": "372:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -151,11 +151,11 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "dataoffset",
-                                                            "nativeSrc": "362:10:0",
+                                                            "nativeSrc": "361:10:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "362:26:0",
+                                                        "nativeSrc": "361:26:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
@@ -164,7 +164,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "399:14:0",
+                                                                "nativeSrc": "398:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -173,26 +173,26 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "datasize",
-                                                            "nativeSrc": "390:8:0",
+                                                            "nativeSrc": "389:8:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "390:24:0",
+                                                        "nativeSrc": "389:24:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
                                                 ],
                                                 "functionName": {
                                                     "name": "codecopy",
-                                                    "nativeSrc": "349:8:0",
+                                                    "nativeSrc": "348:8:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "349:66:0",
+                                                "nativeSrc": "348:66:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "349:66:0",
+                                            "nativeSrc": "348:66:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         },
@@ -201,7 +201,7 @@
                                                 "arguments": [
                                                     {
                                                         "name": "_1",
-                                                        "nativeSrc": "435:2:0",
+                                                        "nativeSrc": "434:2:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
@@ -210,7 +210,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "448:14:0",
+                                                                "nativeSrc": "447:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -219,26 +219,26 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "datasize",
-                                                            "nativeSrc": "439:8:0",
+                                                            "nativeSrc": "438:8:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "439:24:0",
+                                                        "nativeSrc": "438:24:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
                                                 ],
                                                 "functionName": {
                                                     "name": "return",
-                                                    "nativeSrc": "428:6:0",
+                                                    "nativeSrc": "427:6:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "428:36:0",
+                                                "nativeSrc": "427:36:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "428:36:0",
+                                            "nativeSrc": "427:36:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         }
@@ -246,19 +246,19 @@
                                 },
                                 {
                                     "body": {
-                                        "nativeSrc": "531:23:0",
+                                        "nativeSrc": "530:23:0",
                                         "nodeType": "YulBlock",
                                         "src": "56:13:0",
                                         "statements": [
                                             {
-                                                "nativeSrc": "533:19:0",
+                                                "nativeSrc": "532:19:0",
                                                 "nodeType": "YulAssignment",
                                                 "src": "56:13:0",
                                                 "value": {
                                                     "arguments": [
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "549:2:0",
+                                                            "nativeSrc": "548:2:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -267,18 +267,18 @@
                                                     ],
                                                     "functionName": {
                                                         "name": "mload",
-                                                        "nativeSrc": "543:5:0",
+                                                        "nativeSrc": "542:5:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "543:9:0",
+                                                    "nativeSrc": "542:9:0",
                                                     "nodeType": "YulFunctionCall",
                                                     "src": "56:13:0"
                                                 },
                                                 "variableNames": [
                                                     {
                                                         "name": "memPtr",
-                                                        "nativeSrc": "533:6:0",
+                                                        "nativeSrc": "532:6:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     }
@@ -287,12 +287,12 @@
                                         ]
                                     },
                                     "name": "allocate_unbounded",
-                                    "nativeSrc": "483:71:0",
+                                    "nativeSrc": "482:71:0",
                                     "nodeType": "YulFunctionDefinition",
                                     "returnVariables": [
                                         {
                                             "name": "memPtr",
-                                            "nativeSrc": "516:6:0",
+                                            "nativeSrc": "515:6:0",
                                             "nodeType": "YulTypedName",
                                             "src": "56:13:0",
                                             "type": ""
@@ -302,7 +302,7 @@
                                 },
                                 {
                                     "body": {
-                                        "nativeSrc": "660:16:0",
+                                        "nativeSrc": "659:16:0",
                                         "nodeType": "YulBlock",
                                         "src": "56:13:0",
                                         "statements": [
@@ -311,7 +311,7 @@
                                                     "arguments": [
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "669:1:0",
+                                                            "nativeSrc": "668:1:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -319,7 +319,7 @@
                                                         },
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "672:1:0",
+                                                            "nativeSrc": "671:1:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -328,22 +328,22 @@
                                                     ],
                                                     "functionName": {
                                                         "name": "revert",
-                                                        "nativeSrc": "662:6:0",
+                                                        "nativeSrc": "661:6:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "662:12:0",
+                                                    "nativeSrc": "661:12:0",
                                                     "nodeType": "YulFunctionCall",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "662:12:0",
+                                                "nativeSrc": "661:12:0",
                                                 "nodeType": "YulExpressionStatement",
                                                 "src": "56:13:0"
                                             }
                                         ]
                                     },
                                     "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
-                                    "nativeSrc": "563:113:0",
+                                    "nativeSrc": "562:113:0",
                                     "nodeType": "YulFunctionDefinition",
                                     "src": "56:13:0"
                                 }
@@ -357,12 +357,12 @@
                         {
                             "code": {
                                 "block": {
-                                    "nativeSrc": "747:361:0",
+                                    "nativeSrc": "746:360:0",
                                     "nodeType": "YulBlock",
                                     "src": "-1:-1:0",
                                     "statements": [
                                         {
-                                            "nativeSrc": "761:207:0",
+                                            "nativeSrc": "760:206:0",
                                             "nodeType": "YulBlock",
                                             "src": "-1:-1:0",
                                             "statements": [
@@ -371,7 +371,7 @@
                                                         "arguments": [
                                                             {
                                                                 "kind": "number",
-                                                                "nativeSrc": "836:2:0",
+                                                                "nativeSrc": "835:2:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -381,35 +381,35 @@
                                                                 "arguments": [
                                                                     {
                                                                         "kind": "number",
-                                                                        "nativeSrc": "852:4:0",
+                                                                        "nativeSrc": "851:3:0",
                                                                         "nodeType": "YulLiteral",
                                                                         "src": "56:13:0",
                                                                         "type": "",
-                                                                        "value": "0x80"
+                                                                        "value": "128"
                                                                     }
                                                                 ],
                                                                 "functionName": {
                                                                     "name": "memoryguard",
-                                                                    "nativeSrc": "840:11:0",
+                                                                    "nativeSrc": "839:11:0",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "56:13:0"
                                                                 },
-                                                                "nativeSrc": "840:17:0",
+                                                                "nativeSrc": "839:16:0",
                                                                 "nodeType": "YulFunctionCall",
                                                                 "src": "56:13:0"
                                                             }
                                                         ],
                                                         "functionName": {
                                                             "name": "mstore",
-                                                            "nativeSrc": "829:6:0",
+                                                            "nativeSrc": "828:6:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "829:29:0",
+                                                        "nativeSrc": "828:28:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "829:29:0",
+                                                    "nativeSrc": "828:28:0",
                                                     "nodeType": "YulExpressionStatement",
                                                     "src": "56:13:0"
                                                 },
@@ -418,15 +418,15 @@
                                                         "arguments": [],
                                                         "functionName": {
                                                             "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
-                                                            "nativeSrc": "875:77:0",
+                                                            "nativeSrc": "873:77:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "875:79:0",
+                                                        "nativeSrc": "873:79:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "875:79:0",
+                                                    "nativeSrc": "873:79:0",
                                                     "nodeType": "YulExpressionStatement",
                                                     "src": "56:13:0"
                                                 }
@@ -434,7 +434,7 @@
                                         },
                                         {
                                             "body": {
-                                                "nativeSrc": "1082:16:0",
+                                                "nativeSrc": "1080:16:0",
                                                 "nodeType": "YulBlock",
                                                 "src": "56:13:0",
                                                 "statements": [
@@ -443,7 +443,7 @@
                                                             "arguments": [
                                                                 {
                                                                     "kind": "number",
-                                                                    "nativeSrc": "1091:1:0",
+                                                                    "nativeSrc": "1089:1:0",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "56:13:0",
                                                                     "type": "",
@@ -451,7 +451,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
-                                                                    "nativeSrc": "1094:1:0",
+                                                                    "nativeSrc": "1092:1:0",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "56:13:0",
                                                                     "type": "",
@@ -460,22 +460,22 @@
                                                             ],
                                                             "functionName": {
                                                                 "name": "revert",
-                                                                "nativeSrc": "1084:6:0",
+                                                                "nativeSrc": "1082:6:0",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "56:13:0"
                                                             },
-                                                            "nativeSrc": "1084:12:0",
+                                                            "nativeSrc": "1082:12:0",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "1084:12:0",
+                                                        "nativeSrc": "1082:12:0",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "56:13:0"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
-                                            "nativeSrc": "981:117:0",
+                                            "nativeSrc": "979:117:0",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "56:13:0"
                                         }

--- a/test/cmdlineTests/standard_irOptimized_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_requested/output.json
@@ -7,7 +7,7 @@ object \"C_7\" {
     code {
         {
             /// @src 0:79:121  \"contract C { function f() public pure {} }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -26,7 +26,7 @@ object \"C_7\" {
         code {
             {
                 /// @src 0:79:121  \"contract C { function f() public pure {} }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_debuginfo_ethdebug_compatible/output.json
+++ b/test/cmdlineTests/standard_output_debuginfo_ethdebug_compatible/output.json
@@ -185,7 +185,7 @@ object \"A1_14\" {
     code {
         {
             /// @src 0:58:123
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -204,7 +204,7 @@ object \"A1_14\" {
         code {
             {
                 /// @src 0:58:123
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -479,7 +479,7 @@ object \"A2_27\" {
     code {
         {
             /// @src 0:124:189
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -498,7 +498,7 @@ object \"A2_27\" {
         code {
             {
                 /// @src 0:124:189
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -775,7 +775,7 @@ object \"A1_42\" {
     code {
         {
             /// @src 1:58:123
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -794,7 +794,7 @@ object \"A1_42\" {
         code {
             {
                 /// @src 1:58:123
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -1069,7 +1069,7 @@ object \"B2_55\" {
     code {
         {
             /// @src 1:124:189
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -1088,7 +1088,7 @@ object \"B2_55\" {
         code {
             {
                 /// @src 1:124:189
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_selection_ethdebug_bytecode_and_deployedbytecode_iroptimized/output.json
+++ b/test/cmdlineTests/standard_output_selection_ethdebug_bytecode_and_deployedbytecode_iroptimized/output.json
@@ -16,7 +16,7 @@ object \"A1_14\" {
     code {
         {
             /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -35,7 +35,7 @@ object \"A1_14\" {
         code {
             {
                 /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -141,7 +141,7 @@ object \"A2_27\" {
     code {
         {
             /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -160,7 +160,7 @@ object \"A2_27\" {
         code {
             {
                 /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -268,7 +268,7 @@ object \"A1_42\" {
     code {
         {
             /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -287,7 +287,7 @@ object \"A1_42\" {
         code {
             {
                 /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -393,7 +393,7 @@ object \"B2_55\" {
     code {
         {
             /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -412,7 +412,7 @@ object \"B2_55\" {
         code {
             {
                 /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_selection_ethdebug_bytecode_iroptimized/output.json
+++ b/test/cmdlineTests/standard_output_selection_ethdebug_bytecode_iroptimized/output.json
@@ -13,7 +13,7 @@ object \"A1_14\" {
     code {
         {
             /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -32,7 +32,7 @@ object \"A1_14\" {
         code {
             {
                 /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -135,7 +135,7 @@ object \"A2_27\" {
     code {
         {
             /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -154,7 +154,7 @@ object \"A2_27\" {
         code {
             {
                 /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -259,7 +259,7 @@ object \"A1_42\" {
     code {
         {
             /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -278,7 +278,7 @@ object \"A1_42\" {
         code {
             {
                 /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -381,7 +381,7 @@ object \"B2_55\" {
     code {
         {
             /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -400,7 +400,7 @@ object \"B2_55\" {
         code {
             {
                 /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_selection_ethdebug_deployedbytecode_iroptimized/output.json
+++ b/test/cmdlineTests/standard_output_selection_ethdebug_deployedbytecode_iroptimized/output.json
@@ -13,7 +13,7 @@ object \"A1_14\" {
     code {
         {
             /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -32,7 +32,7 @@ object \"A1_14\" {
         code {
             {
                 /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -135,7 +135,7 @@ object \"A2_27\" {
     code {
         {
             /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -154,7 +154,7 @@ object \"A2_27\" {
         code {
             {
                 /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -259,7 +259,7 @@ object \"A1_42\" {
     code {
         {
             /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -278,7 +278,7 @@ object \"A1_42\" {
         code {
             {
                 /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -381,7 +381,7 @@ object \"B2_55\" {
     code {
         {
             /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -400,7 +400,7 @@ object \"B2_55\" {
         code {
             {
                 /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_selection_ethdebug_iroptimized/output.json
+++ b/test/cmdlineTests/standard_output_selection_ethdebug_iroptimized/output.json
@@ -13,7 +13,7 @@ object \"A1_14\" {
     code {
         {
             /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -32,7 +32,7 @@ object \"A1_14\" {
         code {
             {
                 /// @src 0:58:123  \"contract A1 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -135,7 +135,7 @@ object \"A2_27\" {
     code {
         {
             /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -154,7 +154,7 @@ object \"A2_27\" {
         code {
             {
                 /// @src 0:124:189  \"contract A2 { function a(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -259,7 +259,7 @@ object \"A1_42\" {
     code {
         {
             /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -278,7 +278,7 @@ object \"A1_42\" {
         code {
             {
                 /// @src 1:58:123  \"contract A1 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))
@@ -381,7 +381,7 @@ object \"B2_55\" {
     code {
         {
             /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -400,7 +400,7 @@ object \"B2_55\" {
         code {
             {
                 /// @src 1:124:189  \"contract B2 { function b(uint x) public pure { assert(x > 0); } }\"
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/standard_output_selection_multiple_matching_source_and_contract_selectors_full_pipeline/output.json
+++ b/test/cmdlineTests/standard_output_selection_multiple_matching_source_and_contract_selectors_full_pipeline/output.json
@@ -70,7 +70,7 @@ object \"A_1\" {
 object \"A_1\" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize(\"A_1_deployed\")
@@ -105,7 +105,7 @@ object \"A_1\" {
 object \"A_5\" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize(\"A_5_deployed\")

--- a/test/cmdlineTests/storage_layout_specifier_smoke_ir_codegen/output
+++ b/test/cmdlineTests/storage_layout_specifier_smoke_ir_codegen/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_7" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             sstore(0x2a, 0x0a)

--- a/test/cmdlineTests/storage_transient_storage_collision_ir_output/output
+++ b/test/cmdlineTests/storage_transient_storage_collision_ir_output/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_25" {
     code {
         {
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -53,7 +53,7 @@ object "C_25" {
     object "C_25_deployed" {
         code {
             {
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/viair_subobjects/output
+++ b/test/cmdlineTests/viair_subobjects/output
@@ -10,7 +10,7 @@ object "C_3" {
     code {
         {
             /// @src 0:82:95  "contract C {}"
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_3_deployed")
@@ -42,7 +42,7 @@ object "D_16" {
     code {
         {
             /// @src 0:96:165  "contract D {..."
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("D_16_deployed")
@@ -55,7 +55,7 @@ object "D_16" {
         code {
             {
                 /// @src 0:96:165  "contract D {..."
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))
                 {
@@ -93,7 +93,7 @@ object "D_16" {
             code {
                 {
                     /// @src 0:82:95  "contract C {}"
-                    let _1 := memoryguard(0x80)
+                    let _1 := memoryguard(128)
                     mstore(64, _1)
                     if callvalue() { revert(0, 0) }
                     let _2 := datasize("C_3_deployed")

--- a/test/cmdlineTests/yul_optimizer_erc7201_literal_comptime_evaluation/output
+++ b/test/cmdlineTests/yul_optimizer_erc7201_literal_comptime_evaluation/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_12" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_12_deployed")
@@ -15,7 +15,7 @@ object "C_12" {
     object "C_12_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))
                 {

--- a/test/cmdlineTests/yul_optimizer_erc7201_param_calldata/output
+++ b/test/cmdlineTests/yul_optimizer_erc7201_param_calldata/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_14" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_14_deployed")
@@ -15,7 +15,7 @@ object "C_14" {
     object "C_14_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0x91e145ef, shr(224, calldataload(0)))

--- a/test/cmdlineTests/yul_optimizer_erc7201_param_memory/output
+++ b/test/cmdlineTests/yul_optimizer_erc7201_param_memory/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_16" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := datasize("C_16_deployed")
@@ -15,7 +15,7 @@ object "C_16" {
     object "C_16_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0x26121ff0, shr(224, calldataload(0)))

--- a/test/cmdlineTests/yul_optimizer_erc7201_param_storage/output
+++ b/test/cmdlineTests/yul_optimizer_erc7201_param_storage/output
@@ -3,7 +3,7 @@ Optimized IR:
 object "C_15" {
     code {
         {
-            let _1 := memoryguard(0x80)
+            let _1 := memoryguard(128)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
             let _2 := sload(0x00)
@@ -39,7 +39,7 @@ object "C_15" {
     object "C_15_deployed" {
         code {
             {
-                let _1 := memoryguard(0x80)
+                let _1 := memoryguard(128)
                 if iszero(lt(calldatasize(), 4))
                 {
                     if eq(0x26121ff0, shr(224, calldataload(0)))

--- a/test/cmdlineTests/yul_optimizer_steps/output
+++ b/test/cmdlineTests/yul_optimizer_steps/output
@@ -4,7 +4,7 @@ object "C_7" {
     code {
         {
             /// @src 0:80:112  "contract C..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -23,7 +23,7 @@ object "C_7" {
         code {
             {
                 /// @src 0:80:112  "contract C..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()
             }
             function revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()

--- a/test/cmdlineTests/yul_optimizer_steps_nested_brackets/output
+++ b/test/cmdlineTests/yul_optimizer_steps_nested_brackets/output
@@ -4,7 +4,7 @@ object "C_6" {
     code {
         {
             /// @src 0:60:103  "contract C..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -26,7 +26,7 @@ object "C_6" {
         code {
             {
                 /// @src 0:60:103  "contract C..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))

--- a/test/cmdlineTests/yul_optimizer_steps_short_sequence/output
+++ b/test/cmdlineTests/yul_optimizer_steps_short_sequence/output
@@ -4,7 +4,7 @@ object "C_8" {
     code {
         {
             /// @src 0:80:221  "contract C {..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             /// @src 0:129:213  "assembly (\"memory-safe\") {..."
             revert(0, 0)
         }
@@ -14,7 +14,7 @@ object "C_8" {
         code {
             {
                 /// @src 0:80:221  "contract C {..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 revert(0, 0)
             }
         }

--- a/test/cmdlineTests/yul_optimizer_steps_with_empty_cleanup_sequence/output
+++ b/test/cmdlineTests/yul_optimizer_steps_with_empty_cleanup_sequence/output
@@ -4,7 +4,7 @@ object "C_8" {
     code {
         {
             /// @src 0:80:314  "contract C {..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             /// @src 0:129:306  "assembly (\"memory-safe\") {..."
             let usr$a := 0
             revert(0, usr$a)
@@ -15,7 +15,7 @@ object "C_8" {
         code {
             {
                 /// @src 0:80:314  "contract C {..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 revert(0, 0)
             }
         }

--- a/test/cmdlineTests/yul_optimizer_steps_with_empty_optimization_sequence/output
+++ b/test/cmdlineTests/yul_optimizer_steps_with_empty_optimization_sequence/output
@@ -4,7 +4,7 @@ object "C_8" {
     code {
         {
             /// @src 0:80:314  "contract C {..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             /// @src 0:129:306  "assembly (\"memory-safe\") {..."
             let usr$a := 0
             revert(0, usr$a)
@@ -15,7 +15,7 @@ object "C_8" {
         code {
             {
                 /// @src 0:80:314  "contract C {..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 revert(0, 0)
             }
         }

--- a/test/cmdlineTests/yul_optimizer_steps_without_optimize_empty_sequence/output
+++ b/test/cmdlineTests/yul_optimizer_steps_without_optimize_empty_sequence/output
@@ -6,7 +6,7 @@ object "C_28" {
     code {
         {
             /// @src 0:60:410  "contract C..."
-            mstore(64, memoryguard(0x80))
+            mstore(64, memoryguard(128))
             if callvalue()
             {
                 revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
@@ -29,7 +29,7 @@ object "C_28" {
         code {
             {
                 /// @src 0:60:410  "contract C..."
-                mstore(64, memoryguard(0x80))
+                mstore(64, memoryguard(128))
                 if iszero(lt(calldatasize(), 4))
                 {
                     let selector := shift_right_unsigned(calldataload(0))


### PR DESCRIPTION
## Description

Skip running StackLimitEvader when StackCompressor determines that there are no stack-too-deep problems.
This avoids rebuilding the cfg, and repeating the same analysis.

It also avoids the rewriting of memoryguard literals from decimal to hex in the otherwise-noop case
that we now skip, hence the updated test output file changes. (Previously eg `memoryguard(128)` would be rewritten to `memoryguard(0x80)` unconditionally)

On Uniswap v4-core, this reduces allocation calls by 19.085M (−3.2071%) and requested bytes by 3.396 GB (−3.7172%).

```
Baseline: 0.8.37-ci.2026.8.6+commit.9b2f86be.Linux.g++ n=3
Target:   0.8.37-ci.2026.8.13+commit.7858cdc6.Linux.g++ n=3
Values are mean ± sample stddev. Δ% = (target mean - baseline mean) / baseline mean. Negative = improvement (lower is better), positive = regression.
winner = '~noise' unless the gap passes a Welch t-test and |Δ%| ≥ 0.1%.

Benchmark                Pipeline  Metric         Base                   Target                 Δ%      winner
-----------------------  --------  -------------  ---------------------  ---------------------  ------  --------
openzeppelin-5.6.1       evmasm    cpu_time       18.2369s ± 0.0193s     18.2746s ± 0.0101s     +0.21%  ~noise
                                   creation_size  725,287 ± 0            725,287 ± 0            0.0%    tie
                                   cycles         63.2694G ± 77.7217M    63.3187G ± 30.0288M    +0.08%  ~noise
                                   instructions   124.9823G ± 473        125.1079G ± 278        +0.1%   BASELINE
                                   peak_rss       1015 ± 0 MiB           1066 ± 0 MiB           +5.01%  BASELINE
                                   runtime_size   650,752 ± 0            650,752 ± 0            0.0%    tie
                                   wall_time      18.3659s ± 0.0175s     18.4003s ± 0.0087s     +0.19%  ~noise

openzeppelin-5.6.1       ir        cpu_time       52.1626s ± 0.0527s     50.3149s ± 0.0150s     -3.54%  TARGET
                                   creation_size  675,405 ± 0            675,405 ± 0            0.0%    tie
                                   cycles         184.5272G ± 174.2462M  177.9435G ± 44.9278M   -3.57%  TARGET
                                   instructions   300.9914G ± 1.1239k    288.9893G ± 426        -3.99%  TARGET
                                   peak_rss       1387 ± 0 MiB           1388 ± 0 MiB           +0.12%  BASELINE
                                   runtime_size   598,355 ± 0            598,355 ± 0            0.0%    tie
                                   wall_time      52.4456s ± 0.0532s     50.5925s ± 0.0165s     -3.53%  TARGET

solady-0.1.26            evmasm    cpu_time       25.4536s ± 0.0512s     25.4753s ± 0.0133s     +0.09%  ~noise
                                   creation_size  1,514,791 ± 0          1,514,791 ± 0          0.0%    tie
                                   cycles         87.5712G ± 174.8606M   87.7038G ± 57.2997M    +0.15%  ~noise
                                   instructions   182.2905G ± 222        182.4166G ± 352        +0.07%  ~noise
                                   peak_rss       1813 ± 0 MiB           1812 ± 0 MiB           -0.08%  ~noise
                                   runtime_size   1,480,154 ± 0          1,480,154 ± 0          0.0%    tie
                                   wall_time      25.6441s ± 0.0450s     25.6659s ± 0.0232s     +0.08%  ~noise

solady-0.1.26            ir        cpu_time       132.6701s ± 0.0816s    128.0828s ± 0.0517s    -3.46%  TARGET
                                   creation_size  1,681,895 ± 0          1,681,895 ± 0          0.0%    tie
                                   cycles         471.0342G ± 319.0700M  454.5971G ± 179.7754M  -3.49%  TARGET
                                   instructions   682.6695G ± 73         655.2556G ± 364        -4.02%  TARGET
                                   peak_rss       2785 ± 0 MiB           2786 ± 0 MiB           +0.06%  ~noise
                                   runtime_size   1,650,497 ± 0          1,650,497 ± 0          0.0%    tie
                                   wall_time      133.3793s ± 0.0978s    128.7534s ± 0.0557s    -3.47%  TARGET

prb-math-4.1.1           evmasm    cpu_time       6.6805s ± 0.0164s      6.6862s ± 0.0020s      +0.09%  ~noise
                                   creation_size  252,039 ± 0            252,039 ± 0            0.0%    tie
                                   cycles         21.4643G ± 67.4157M    21.4950G ± 22.8553M    +0.14%  ~noise
                                   instructions   45.7352G ± 136         45.7425G ± 97          +0.02%  ~noise
                                   peak_rss       1171 ± 0 MiB           1171 ± 0 MiB           0.0%    tie
                                   runtime_size   250,178 ± 0            250,178 ± 0            0.0%    tie
                                   wall_time      6.7311s ± 0.0226s      6.7406s ± 0.0108s      +0.14%  ~noise

prb-math-4.1.1           ir        cpu_time       26.8109s ± 0.0093s     26.2661s ± 0.0125s     -2.03%  TARGET
                                   creation_size  262,432 ± 0            262,432 ± 0            0.0%    tie
                                   cycles         93.2943G ± 37.6994M    91.3638G ± 44.0117M    -2.07%  TARGET
                                   instructions   145.0668G ± 428        141.6537G ± 295        -2.35%  TARGET
                                   peak_rss       1430 ± 0 MiB           1434 ± 0 MiB           +0.26%  BASELINE
                                   runtime_size   260,832 ± 0            260,832 ± 0            0.0%    tie
                                   wall_time      26.9518s ± 0.0044s     26.4058s ± 0.0115s     -2.03%  TARGET

forge-std-1.16.1         evmasm    cpu_time       8.0321s ± 0.0103s      8.0030s ± 0.0020s      -0.36%  TARGET
                                   creation_size  394,603 ± 0            394,603 ± 0            0.0%    tie
                                   cycles         27.6142G ± 32.9076M    27.5275G ± 3.6783M     -0.31%  TARGET
                                   instructions   54.8421G ± 248         54.8666G ± 83          +0.04%  ~noise
                                   peak_rss       542 ± 0 MiB            541 ± 0 MiB            -0.1%   TARGET
                                   runtime_size   381,729 ± 0            381,729 ± 0            0.0%    tie
                                   wall_time      8.0877s ± 0.0198s      8.0564s ± 0.0062s      -0.39%  ~noise

forge-std-1.16.1         ir        cpu_time       34.6354s ± 0.0248s     33.6999s ± 0.0142s     -2.7%   TARGET
                                   creation_size  422,073 ± 0            422,073 ± 0            0.0%    tie
                                   cycles         122.7875G ± 90.3700M   119.3914G ± 46.9614M   -2.77%  TARGET
                                   instructions   179.8147G ± 227        173.4876G ± 249        -3.52%  TARGET
                                   peak_rss       758 ± 0 MiB            783 ± 0 MiB            +3.24%  BASELINE
                                   runtime_size   406,750 ± 0            406,750 ± 0            0.0%    tie
                                   wall_time      34.8104s ± 0.0177s     33.8796s ± 0.0113s     -2.67%  TARGET

v4-core-4.0.0            evmasm    cpu_time       16.0804s ± 0.0128s     16.0955s ± 0.0229s     +0.09%  ~noise
                                   creation_size  2,012,188 ± 0          2,012,188 ± 0          0.0%    tie
                                   cycles         55.8132G ± 32.3274M    55.8782G ± 89.4153M    +0.12%  ~noise
                                   instructions   110.3795G ± 49         110.5018G ± 317        +0.11%  BASELINE
                                   peak_rss       861 ± 0 MiB            862 ± 0 MiB            +0.07%  ~noise
                                   runtime_size   1,983,262 ± 0          1,983,262 ± 0          0.0%    tie
                                   wall_time      16.1980s ± 0.0133s     16.2077s ± 0.0228s     +0.06%  ~noise

v4-core-4.0.0            ir        cpu_time       89.5287s ± 0.0238s     87.4018s ± 0.0392s     -2.38%  TARGET
                                   creation_size  1,804,635 ± 0          1,804,635 ± 0          0.0%    tie
                                   cycles         318.1867G ± 95.7863M   310.4663G ± 145.3140M  -2.43%  TARGET
                                   instructions   480.9478G ± 1.4668k    467.6325G ± 749        -2.77%  TARGET
                                   peak_rss       1617 ± 0 MiB           1615 ± 0 MiB           -0.11%  TARGET
                                   runtime_size   1,777,945 ± 0          1,777,945 ± 0          0.0%    tie
                                   wall_time      89.9842s ± 0.0219s     87.8462s ± 0.0410s     -2.38%  TARGET

morpho-blue-1.0.0        evmasm    cpu_time       9.2900s ± 0.0134s      9.3192s ± 0.0063s      +0.31%  BASELINE
                                   creation_size  802,290 ± 0            802,290 ± 0            0.0%    tie
                                   cycles         32.2336G ± 50.1880M    32.3484G ± 29.7335M    +0.36%  BASELINE
                                   instructions   65.0197G ± 222         65.0657G ± 180         +0.07%  ~noise
                                   peak_rss       542 ± 0 MiB            541 ± 0 MiB            -0.1%   TARGET
                                   runtime_size   798,085 ± 0            798,085 ± 0            0.0%    tie
                                   wall_time      9.3493s ± 0.0125s      9.3862s ± 0.0056s      +0.39%  BASELINE

morpho-blue-1.0.0        ir        cpu_time       51.1071s ± 0.0480s     50.9301s ± 0.0256s     -0.35%  TARGET
                                   creation_size  753,526 ± 0            753,526 ± 0            0.0%    tie
                                   cycles         181.6723G ± 178.6852M  181.0903G ± 95.9752M   -0.32%  TARGET
                                   instructions   263.1485G ± 560        261.4888G ± 117        -0.63%  TARGET
                                   peak_rss       875 ± 0 MiB            877 ± 0 MiB            +0.3%   BASELINE
                                   runtime_size   750,240 ± 0            750,240 ± 0            0.0%    tie
                                   wall_time      51.3653s ± 0.0442s     51.1889s ± 0.0261s     -0.34%  TARGET

seaport-1.6              evmasm    cpu_time       108.5253s ± 0.0631s    108.4212s ± 0.1191s    -0.1%   ~noise
                                   creation_size  13,568,823 ± 0         13,568,823 ± 0         0.0%    tie
                                   cycles         376.5852G ± 187.1832M  376.2774G ± 368.9030M  -0.08%  ~noise
                                   instructions   672.5458G ± 3.2772k    672.9423G ± 4.6918k    +0.06%  ~noise
                                   peak_rss       2644 ± 0 MiB           2637 ± 0 MiB           -0.28%  TARGET
                                   runtime_size   12,556,893 ± 0         12,556,893 ± 0         0.0%    tie
                                   wall_time      109.2112s ± 0.0648s    109.1029s ± 0.1351s    -0.1%   ~noise

solmate-6                evmasm    cpu_time       3.5026s ± 0.0027s      3.5026s ± 0.0053s      0.0%    tie
                                   creation_size  279,294 ± 0            279,294 ± 0            0.0%    tie
                                   cycles         12.1756G ± 9.7649M     12.1820G ± 16.1807M    +0.05%  ~noise
                                   instructions   24.8168G ± 181         24.8589G ± 60          +0.17%  BASELINE
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   272,389 ± 0            272,389 ± 0            0.0%    tie
                                   wall_time      3.5290s ± 0.0125s      3.5299s ± 0.0115s      +0.03%  ~noise

solmate-6                ir        cpu_time       18.7255s ± 0.0303s     17.9808s ± 0.0400s     -3.98%  TARGET
                                   creation_size  267,193 ± 0            267,193 ± 0            0.0%    tie
                                   cycles         66.5457G ± 106.5130M   63.8952G ± 138.5058M   -3.98%  TARGET
                                   instructions   98.4781G ± 228         94.0430G ± 357         -4.5%   TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   259,851 ± 0            259,851 ± 0            0.0%    tie
                                   wall_time      18.8164s ± 0.0300s     18.0685s ± 0.0398s     -3.97%  TARGET

solarray-a547630         evmasm    cpu_time       1.0186s ± 0.0025s      1.0130s ± 0.0025s      -0.55%  ~noise
                                   creation_size  4,474 ± 0              4,474 ± 0              0.0%    tie
                                   cycles         3.2251G ± 5.4466M      3.2026G ± 15.3649M     -0.7%   ~noise
                                   instructions   7.6376G ± 23           7.6265G ± 23           -0.15%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   3,992 ± 0              3,992 ± 0              0.0%    tie
                                   wall_time      1.0272s ± 0.0040s      1.0203s ± 0.0024s      -0.67%  ~noise

solarray-a547630         ir        cpu_time       1.1946s ± 0.0029s      1.1939s ± 0.0009s      -0.06%  ~noise
                                   creation_size  4,220 ± 0              4,220 ± 0              0.0%    tie
                                   cycles         3.8556G ± 9.4355M      3.8531G ± 1.6205M      -0.07%  ~noise
                                   instructions   8.7550G ± 32           8.7065G ± 10           -0.55%  TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   3,920 ± 0              3,920 ± 0              0.0%    tie
                                   wall_time      1.2033s ± 0.0028s      1.2024s ± 0.0011s      -0.08%  ~noise

solidity-verifier        evmasm    cpu_time       0.1060s ± 0.0002s      0.1063s ± 0.0003s      +0.29%  ~noise
                                   creation_size  4,790 ± 0              4,790 ± 0              0.0%    tie
                                   cycles         295.5401M ± 167.5773k  296.3735M ± 508.8326k  +0.28%  ~noise
                                   instructions   635.5532M ± 5          636.9812M ± 9          +0.22%  BASELINE
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   4,712 ± 0              4,712 ± 0              0.0%    tie
                                   wall_time      0.1070s ± 0.0002s      0.1072s ± 0.0003s      +0.18%  ~noise

solidity-verifier        ir        cpu_time       0.2218s ± 0.0002s      0.2147s ± 0.0001s      -3.2%   TARGET
                                   creation_size  4,215 ± 0              4,215 ± 0              0.0%    tie
                                   cycles         709.3663M ± 230.6292k  683.7439M ± 122.8496k  -3.61%  TARGET
                                   instructions   1.3577G ± 32           1.3102G ± 8            -3.5%   TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   4,161 ± 0              4,161 ± 0              0.0%    tie
                                   wall_time      0.2233s ± 0.0004s      0.2161s ± 0.0002s      -3.21%  TARGET

solidity-optimizor-club  ir        cpu_time       1.0816s ± 0.0020s      1.0491s ± 0.0017s      -3.01%  TARGET
                                   creation_size  21,778 ± 0             21,778 ± 0             0.0%    tie
                                   cycles         3.7407G ± 5.2469M      3.6258G ± 6.8670M      -3.07%  TARGET
                                   instructions   7.0230G ± 45           6.7913G ± 23           -3.3%   TARGET
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   20,616 ± 0             20,616 ± 0             0.0%    tie
                                   wall_time      1.0874s ± 0.0019s      1.0546s ± 0.0018s      -3.01%  TARGET

solidity-chains          evmasm    cpu_time       0.1113s ± 0.0002s      0.1116s ± 0.0005s      +0.28%  ~noise
                                   creation_size  5,831 ± 0              5,831 ± 0              0.0%    tie
                                   cycles         317.8958M ± 567.3079k  318.6019M ± 694.3545k  +0.22%  ~noise
                                   instructions   650.1319M ± 11         651.3160M ± 11         +0.18%  BASELINE
                                   peak_rss       848 ± 0 MiB            848 ± 0 MiB            +0.01%  ~noise
                                   runtime_size   5,803 ± 0              5,803 ± 0              0.0%    tie
                                   wall_time      0.1121s ± 0.0003s      0.1124s ± 0.0006s      +0.23%  ~noise
                                   ```

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

gpt 5.6 sol xhigh for everything