### PR TITLE
yul optimizer: expose SCCs derived from yul call graph

### DIFF
--- a/libyul/optimiser/CallGraphGenerator.cpp
+++ b/libyul/optimiser/CallGraphGenerator.cpp
@@ -19,9 +19,9 @@
  * Specific AST walker that generates the call graph.
  */
 
-#include <libyul/AST.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
 
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 #include <libsolutil/CommonData.h>
@@ -78,7 +78,7 @@ private:
 
 }
 
-std::set<FunctionHandle> CallGraph::recursiveFunctions() const
+CallGraphCycles CallGraph::analyzeCallCycles() const
 {
 	// A function is recursive iff it is part of a non-trivial strongly-connected component of the call graph (a
 	// mutual-recursion cycle of any length) or it directly calls itself. The SCCs are computed with Tarjan's algorithm.
@@ -99,23 +99,30 @@ std::set<FunctionHandle> CallGraph::recursiveFunctions() const
 		callees.erase(ranges::unique(callees), callees.end());
 	}
 
+	std::vector<std::vector<FunctionHandle>> components;
 	std::set<FunctionHandle> recursiveFunctionHandleSet;
 	for (std::vector<std::size_t> const& scc: util::computeStronglyConnectedComponents<std::size_t>(indexBasedAdjacencyList))
 	{
 		yulAssert(!scc.empty());
-		if (scc.size() > 1)
+		std::vector<FunctionHandle>& component = components.emplace_back();
+		for (std::size_t const node: scc)
+			component.emplace_back(functionIndexBimap.indexToFunction(node));
+		if (component.size() > 1)
 			// more than one element in the SCC: everything in it is mutually recursive
-			for (std::size_t const node: scc)
-				recursiveFunctionHandleSet.insert(functionIndexBimap.indexToFunction(node));
+			recursiveFunctionHandleSet.insert(component.begin(), component.end());
 		else if (ranges::binary_search(indexBasedAdjacencyList[scc.front()], scc.front()))
 			// self-recursion f -> f
-			recursiveFunctionHandleSet.insert(functionIndexBimap.indexToFunction(scc.front()));
+			recursiveFunctionHandleSet.insert(component.front());
 	}
 
 	yulAssert(!recursiveFunctionHandleSet.contains(YulName{}), "the top-level block cannot be recursive");
 	for (FunctionHandle const& recursiveFunction: recursiveFunctionHandleSet)
 		yulAssert(std::holds_alternative<YulName>(recursiveFunction), "a builtin cannot be recursive");
-	return recursiveFunctionHandleSet;
+
+	return {
+		.stronglyConnectedComponents = std::move(components),
+		.recursiveFunctions = std::move(recursiveFunctionHandleSet)
+	};
 }
 
 CallGraph CallGraphGenerator::callGraph(Block const& _ast)
@@ -161,4 +168,3 @@ CallGraphGenerator::CallGraphGenerator()
 {
 	m_callGraph.functionCalls[YulName{}] = {};
 }
-

--- a/libyul/optimiser/CallGraphGenerator.h
+++ b/libyul/optimiser/CallGraphGenerator.h
@@ -24,26 +24,37 @@
 #pragma once
 
 #include <libyul/optimiser/ASTWalker.h>
-#include <libyul/AST.h>
+
+#include <libyul/Builtins.h>
 
 #include <map>
 #include <set>
+#include <vector>
 
 namespace solidity::yul
 {
 
+/**
+ * Cycle structure of a call graph, derived from it by CallGraph::analyzeCallCycles
+ */
+struct CallGraphCycles
+{
+	/// The strongly-connected components of the call graph.
+	std::vector<std::vector<FunctionHandle>> stronglyConnectedComponents;
+	/// The set of functions contained in cycles in the call graph, i.e., functions that are part of a
+	/// (mutual) recursion. This does not include functions that merely call recursive functions.
+	/// Never contains a builtin: at Yul level builtins cannot call other functions, so they have no
+	/// outgoing call-graph edges and can be neither mutually nor directly recursive.
+	std::set<FunctionHandle> recursiveFunctions;
+};
+
 struct CallGraph
 {
+	CallGraphCycles analyzeCallCycles() const;
+
 	/// Map function definition name -> function name
 	std::map<FunctionHandle, std::vector<FunctionHandle>> functionCalls;
 	std::set<YulName> functionsWithLoops;
-	/// @returns the set of functions contained in cycles in the call graph, i.e.
-	/// functions that are part of a (mutual) recursion.
-	/// Note that this does not include functions that merely call recursive functions.
-	/// Postcondition: the result never contains a builtin. At Yul level builtins cannot call other
-	/// functions, so they have no outgoing call-graph edges and can be neither mutually nor directly
-	/// recursive.
-	std::set<FunctionHandle> recursiveFunctions() const;
 };
 
 /**

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -53,7 +53,7 @@ void FullInliner::run(OptimiserStepContext& _context, Block& _ast)
 
 FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser, Dialect const& _dialect):
 	m_ast(_ast),
-	m_recursiveFunctions(CallGraphGenerator::callGraph(_ast).recursiveFunctions()),
+	m_recursiveFunctions(CallGraphGenerator::callGraph(_ast).analyzeCallCycles().recursiveFunctions),
 	m_nameDispenser(_dispenser),
 	m_dialect(_dialect)
 {

--- a/libyul/optimiser/FunctionSpecializer.cpp
+++ b/libyul/optimiser/FunctionSpecializer.cpp
@@ -129,7 +129,7 @@ FunctionDefinition FunctionSpecializer::specialize(
 void FunctionSpecializer::run(OptimiserStepContext& _context, Block& _ast)
 {
 	FunctionSpecializer f{
-		CallGraphGenerator::callGraph(_ast).recursiveFunctions(),
+		CallGraphGenerator::callGraph(_ast).analyzeCallCycles().recursiveFunctions,
 		_context.dispenser
 	};
 	f(_ast);

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -137,7 +137,8 @@ std::map<FunctionHandle, SideEffects> SideEffectsPropagator::sideEffects(
 		ret[function].cannotLoop = false;
 	}
 
-	for (auto const& function: _directCallGraph.recursiveFunctions())
+	CallGraphCycles const callCycles = _directCallGraph.analyzeCallCycles();
+	for (auto const& function: callCycles.recursiveFunctions)
 	{
 		ret[function].movable = false;
 		ret[function].canBeRemoved = false;

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -207,9 +207,10 @@ void StackLimitEvader::run(
 			return;
 
 	CallGraph callGraph = CallGraphGenerator::callGraph(_astRoot);
+	CallGraphCycles const callCycles = callGraph.analyzeCallCycles();
 
 	// We cannot move variables in recursive functions to fixed memory offsets.
-	for (FunctionHandle function: callGraph.recursiveFunctions())
+	for (FunctionHandle function: callCycles.recursiveFunctions)
 	{
 		yulAssert(std::holds_alternative<YulName>(function), "Builtins are not recursive.");
 		if (_unreachableVariables.count(std::get<YulName>(function)))

--- a/test/libyul/CallGraphTest.cpp
+++ b/test/libyul/CallGraphTest.cpp
@@ -94,7 +94,7 @@ TestCase::TestResult CallGraphTest::run(std::ostream& _stream, std::string const
 	try
 	{
 		CallGraph const callGraph = CallGraphGenerator::callGraph(root);
-		std::set<FunctionHandle> const recursiveFunctionHandles = callGraph.recursiveFunctions();
+		std::set<FunctionHandle> const recursiveFunctionHandles = callGraph.analyzeCallCycles().recursiveFunctions;
 		Dialect const& dialect = yulStack.dialect();
 
 		auto printNode = [&](YulName const _name) {

--- a/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
+++ b/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
@@ -54,7 +54,7 @@ namespace
 /// @returns true if there are recursive functions, false otherwise.
 bool recursiveFunctionExists(Dialect const& /*_dialect*/, yul::Object& _object)
 {
-	auto recursiveFunctions = CallGraphGenerator::callGraph(_object.code()->root()).recursiveFunctions();
+	auto recursiveFunctions = CallGraphGenerator::callGraph(_object.code()->root()).analyzeCallCycles().recursiveFunctions;
 	for(auto&& [function, variables]: CompilabilityChecker{
 			_object,
 			true


### PR DESCRIPTION
a small refactor of `CallGraph::recursiveFunctions` that introduces `CallGraph::analyzeCallCycles` which yields an object storing recursive functions as well as SCCs that were computed on the way.