### PR TITLE
Fix ICE and emit error when FixedPointType variables are accessed in inline assembly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
+* Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
 
 Build System:
 * Update minimum version requirement of Boost to 1.83.0 for Windows build. This matches the minimum version for other systems.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -806,7 +806,15 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				}
 			}
 
-			solAssert(!dynamic_cast<FixedPointType const*>(var->type()), "FixedPointType not implemented.");
+			if (dynamic_cast<FixedPointType const*>(var->type()))
+			{
+				m_errorReporter.unimplementedFeatureError(
+					5016_error,
+					nativeLocationOf(_identifier),
+					"Fixed point types are not implemented."
+				);
+				return false;
+			}
 
 			if (!identifierInfo.suffix.empty())
 			{

--- a/test/libsolidity/syntaxTests/inlineAssembly/unimplemented_fixed_type_variable.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/unimplemented_fixed_type_variable.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure returns (fixed x) {
+        assembly {
+            x := 1
+        }
+    }
+}
+// ----
+// UnimplementedFeatureError 5016: (93-94): Fixed point types are not implemented.

--- a/test/libsolidity/syntaxTests/inlineAssembly/unimplemented_ufixed_type_variable.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/unimplemented_ufixed_type_variable.sol
@@ -1,0 +1,10 @@
+contract C {
+    ufixed32x8 y;
+    function f() public {
+        assembly {
+            sstore(y.slot, 1)
+        }
+    }
+}
+// ----
+// UnimplementedFeatureError 5016: (95-101): Fixed point types are not implemented.


### PR DESCRIPTION
Fix #16619.