### PR TITLE
Handle lack of 'next_page_token' in the API json response.

### DIFF
--- a/scripts/common/rest_api_helpers.py
+++ b/scripts/common/rest_api_helpers.py
@@ -121,6 +121,11 @@ class CircleCI:
             json_response = query_api(url, params, headers, self.debug_requests)
 
             yield json_response['items']
+            if 'next_page_token' not in json_response:
+                raise APIHelperError(
+                    f"API response for {url} with params {params} is missing the 'next_page_token' key: "
+                    f"{json_response}"
+                )
             next_page_token = json_response['next_page_token']
             page_count += 1
             if next_page_token is None:


### PR DESCRIPTION
## Description

`next_page_token` is not always present w CI API response. If not handle the error poperly.

## AI Disclosure

- [x] No AI tools were used
