### PR TITLE
IR codegen: Clean dirty storage array indices

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2341,6 +2341,10 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 			{
 				std::string slot = m_context.newYulVariable();
 				std::string offset = m_context.newYulVariable();
+				std::string const indexExpression = expressionAsType(
+					*_indexAccess.indexExpression(),
+					*TypeProvider::uint256()
+				);
 
 				appendCode() << Whiskers(R"(
 					let <slot>, <offset> := <indexFunc>(<array>, <index>)
@@ -2349,7 +2353,7 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 				("offset", offset)
 				("indexFunc", m_utils.storageArrayIndexAccessFunction(arrayType))
 				("array", IRVariable(_indexAccess.baseExpression()).part("slot").name())
-				("index", IRVariable(*_indexAccess.indexExpression()).name())
+				("index", indexExpression)
 				.render();
 
 				setLValue(_indexAccess, IRLValue{

--- a/test/libsolidity/semanticTests/array/indexAccess/storage_array_index_cleanup.sol
+++ b/test/libsolidity/semanticTests/array/indexAccess/storage_array_index_cleanup.sol
@@ -1,0 +1,14 @@
+contract C {
+    uint256[256] values;
+
+    function f() public returns (uint256) {
+        uint8 index;
+        assembly { index := 0x100 }
+        values[0] = 0x1234;
+        return values[index];
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 0x1234


### PR DESCRIPTION
 ## Description

Clean storage-array index expressions by converting them to `uint256` before the via-IR bounds check. Before this PR dirty upper bits in a narrow index could cause an unexpected out-of-bounds panic. I also added regression test covering optimized + unoptimized legacy and via-IR compilation.