### PR TITLE
Fix `c_ext_benchmark`to properly handle circle.ci API response and run benchmarks when they are downloaded.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1760,8 +1760,12 @@ jobs:
               # Our main goal here is to provide new benchmarks, the diff is optional. When benchmarks from
               # the previous run are not available for whatever reason, we still succeed and just skip the diff.
               # download_benchmarks.py exits with status 2 in that case.
-              if "${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr "$pr_id" || [[ $? == 2 ]]; then
+              exit_code=0
+              "${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr "$pr_id" || exit_code=$?
+              if [[ $exit_code == 2 ]]; then
                 echo 'export SKIP_BENCHMARK_DIFF=true' >> $BASH_ENV
+              elif [[ $exit_code != 0 ]]; then
+                exit $exit_code
               fi
             fi
       - run:
@@ -1790,6 +1794,10 @@ jobs:
                 --style absolute \
                 base-branch/all-benchmarks-*.json \
                 all-benchmarks.json > diff/benchmark-diff-all-table-inplace-absolute.md
+            elif [[ $CIRCLE_PULL_REQUEST == "" ]]; then
+              echo "Skipping benchmark diff: not running on a pull request."
+            else
+              echo "Skipping benchmark diff: benchmarks for the base branch are not available."
             fi
       - store_artifacts:
           path: reports/externalTests/diff/

--- a/scripts/common/rest_api_helpers.py
+++ b/scripts/common/rest_api_helpers.py
@@ -121,12 +121,7 @@ class CircleCI:
             json_response = query_api(url, params, headers, self.debug_requests)
 
             yield json_response['items']
-            if 'next_page_token' not in json_response:
-                raise APIHelperError(
-                    f"API response for {url} with params {params} is missing the 'next_page_token' key: "
-                    f"{json_response}"
-                )
-            next_page_token = json_response['next_page_token']
+            next_page_token = json_response.get('next_page_token')
             page_count += 1
             if next_page_token is None:
                 break


### PR DESCRIPTION
## Description

This PR fixes
- a bug in the helper script. `next_page_token` is no always present in the `circle.ci` response. Tested locally. Looks like API inconsistency. 
- a bug in `name: Download reports from base branch` step. `if "${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr “$pr_id" || [[ $? == 2 ]];` goes into `true` branch any time when `"${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr "$pr_id”` returns `0` code. So the benchmarks never ran when the script returned `0`(success). Reference to bash spec: https://www.gnu.org/software/bash/manual/bash.html#Lists and https://www.gnu.org/software/bash/manual/bash.html#Conditional-Constructs

Fixes: https://github.com/argotorg/solidity/issues/15138

## AI Disclosure
- [x] No AI tools were used
