### PR TITLE
Fix boost filesystem compatibility issue

### DIFF
--- a/test/libsolidity/syntaxTests/imports/relative_import_from_url_named_source.sol
+++ b/test/libsolidity/syntaxTests/imports/relative_import_from_url_named_source.sol
@@ -1,0 +1,8 @@
+==== Source: https://example.com/token/Context.sol ====
+contract Context {}
+==== Source: https://example.com/token/Ownable.sol ====
+import "./Context.sol";
+contract Ownable is Context {}
+==== Source: https://example.com/utils/Strings.sol ====
+import "../token/Ownable.sol";
+contract Strings is Ownable {}


### PR DESCRIPTION
From the [boost::filesystem release history](https://www.boost.org/doc/libs/latest/libs/filesystem/doc/release_history.html) under v1.85.0: 
> path::generic_path and path::generic_string methods now remove duplicate directory separators in the returned paths.
