### PR TITLE
Fix source reference extractor for multi-byte characters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 * General: Remove support for the experimental Generic Solidity prototype (`pragma experimental solidity`).
 * SMTChecker: Emit a deprecation warning for the BMC engine.
 * SMTChecker: Support `block.slotnum`.
+* Standard JSON Interface: Fix the entire output being replaced by a `JSONError` ("Error writing output JSON.") when an error message quotes a long source line and truncating it splits a multi-byte character.
 
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.

--- a/liblangutil/SourceReferenceExtractor.cpp
+++ b/liblangutil/SourceReferenceExtractor.cpp
@@ -22,10 +22,30 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <string_view>
 #include <variant>
 
 using namespace solidity;
 using namespace solidity::langutil;
+
+namespace
+{
+
+// If `_position` points into the middle of a multi-byte character, yield the beginning of the character. Otherwise,
+// this is the identity.
+std::string::size_type toUTF8SequenceStart(std::string_view const _text, std::string::size_type _position)
+{
+	while (
+		_position > 0 &&
+		_position < _text.size() &&
+		(static_cast<std::byte>(_text[_position]) & std::byte{0xc0}) == std::byte{0x80}
+	)
+		--_position;
+	return _position;
+}
+
+}
 
 SourceReferenceExtractor::Message SourceReferenceExtractor::extract(
 	CharStreamProvider const& _charStreamProvider,
@@ -86,8 +106,11 @@ SourceReference SourceReferenceExtractor::extract(
 
 	if (locationLength > 150)
 	{
-		auto const lhs = static_cast<size_t>(start.column) + 35;
-		std::string::size_type const rhs = (isMultiline ? line.length() : static_cast<size_t>(end.column)) - 35;
+		std::string::size_type const lhs = toUTF8SequenceStart(line, static_cast<std::string::size_type>(start.column) + 35);
+		std::string::size_type const rhs = toUTF8SequenceStart(
+			line,
+			(isMultiline ? line.length() : static_cast<size_t>(end.column)) - 35
+		);
 		line = line.substr(0, lhs) + " ... " + line.substr(rhs);
 		end.column = start.column + 75;
 		locationLength = 75;
@@ -96,12 +119,13 @@ SourceReference SourceReferenceExtractor::extract(
 	if (line.length() > 150)
 	{
 		int const len = static_cast<int>(line.length());
-		line = line.substr(
-			static_cast<size_t>(std::max(0, start.column - 35)),
-			static_cast<size_t>(std::min(start.column, 35)) + static_cast<size_t>(
-				std::min(locationLength + 35, len - start.column)
-			)
+		std::string::size_type const cutStart = toUTF8SequenceStart(line, static_cast<std::string::size_type>(std::max(0, start.column - 35)));
+		std::string::size_type const cutEnd = toUTF8SequenceStart(
+			line,
+			static_cast<std::string::size_type>(start.column) + static_cast<std::string::size_type>(std::min(locationLength + 35, len - start.column))
 		);
+		solAssert(cutEnd >= cutStart);
+		line = line.substr(cutStart, cutEnd - cutStart);
 		if (start.column + locationLength + 35 < len)
 			line += " ...";
 		if (start.column > 35)

--- a/test/cmdlineTests/standard_json_snippet_truncation_utf8/input.json
+++ b/test/cmdlineTests/standard_json_snippet_truncation_utf8/input.json
@@ -1,0 +1,15 @@
+{
+ "language": "Solidity",
+ "sources": {
+  "A": {
+   "content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract C {\n    string private eyes = unicode\"€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€€\";\n    function f() public pure {\n        string memory eyes;\n        eyes = eyes;\n    }\n}"
+  }
+ },
+ "settings": {
+  "outputSelection": {
+   "*": {
+    "*": []
+   }
+  }
+ }
+}

--- a/test/cmdlineTests/standard_json_snippet_truncation_utf8/output.json
+++ b/test/cmdlineTests/standard_json_snippet_truncation_utf8/output.json
@@ -1,1 +1,41 @@
-{"errors":[{"type":"JSONError","component":"general","severity":"error","message":"Error writing output JSON."}]}
+{
+    "errors": [
+        {
+            "component": "general",
+            "errorCode": "2519",
+            "formattedMessage": "Warning: This declaration shadows an existing declaration.
+ --> A:6:9:
+  |
+6 |         string memory eyes;
+  |         ^^^^^^^^^^^^^^^^^^
+Note: The shadowed declaration is here:
+ --> A:4:5:
+  |
+4 |     string private eyes = unicode\"\u20ac ... \u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\u20ac\";
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+",
+            "message": "This declaration shadows an existing declaration.",
+            "secondarySourceLocations": [
+                {
+                    "end": 287,
+                    "file": "A",
+                    "message": "The shadowed declaration is here:",
+                    "start": 76
+                }
+            ],
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 346,
+                "file": "A",
+                "start": 328
+            },
+            "type": "Warning"
+        }
+    ],
+    "sources": {
+        "A": {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_json_snippet_truncation_utf8/output.json
+++ b/test/cmdlineTests/standard_json_snippet_truncation_utf8/output.json
@@ -1,0 +1,1 @@
+{"errors":[{"type":"JSONError","component":"general","severity":"error","message":"Error writing output JSON."}]}


### PR DESCRIPTION
When emitting a warning, we provide a source reference to go with it. If the source is long and contains utf8 characters, it could happen (due to the bytewise treatment), that a multi-byte character was cut in half, causing json serialization to yield an error. This fix moves the caret to the beginning of multi-byte characters when extracting the source reference and it is shortened.