### PR TITLE
External tests: Remove experimental ABIEncoderV2 pragma

### DIFF
--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -146,6 +146,13 @@ function replace_version_pragmas
     find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e 's/pragma solidity [^;]+;/pragma solidity >=0.0;/'
 }
 
+function remove_experimental_abi_encoder_v2_pragmas
+{
+    # Remove experimental ABIEncoderV2 pragma. ABI encoder V2 is now the default one.
+    printLog "Removing experimental ABIEncoderV2 pragmas..."
+    find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e '/^pragma experimental "?ABIEncoderV2"?;$/d'
+}
+
 function neutralize_package_lock
 {
     # Remove lock files (if they exist) to prevent them from overriding our changes in package.json

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -70,6 +70,7 @@ function colony_test
     cd ..
 
     replace_version_pragmas
+    remove_experimental_abi_encoder_v2_pragmas
     [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 
     for preset in $SELECTED_PRESETS; do

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -107,6 +107,7 @@ function elementfi_test
     npm install
 
     replace_version_pragmas
+    remove_experimental_abi_encoder_v2_pragmas
 
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn "$config_var"

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -65,6 +65,7 @@ function ens_test
     pnpm install
 
     replace_version_pragmas
+    remove_experimental_abi_encoder_v2_pragmas
     neutralize_packaged_contracts
 
     # In some cases Hardhat does not detect revert reasons properly via IR.


### PR DESCRIPTION
Three of our external tests: `colony`, `ens` and `elementfi` still use `pragma experimental ABIEncoderV2;`.
Since we want to drop support for this pragma, we need to modify the contracts and delete this pragma in the source code.
This change is semantics preserving. V2 is the default (and has been for a long time now).

We add a helper method to remove this pragma and use it in these three external projects.

This follows suite of another helper method we already use to modify the source code of external projects: `replace_version_pragmas`.