### PR TITLE
Change `std::map` to `std::unordered_map` in `SSAValueTracker::m_values`

### DIFF
--- a/libyul/optimiser/SSAValueTracker.h
+++ b/libyul/optimiser/SSAValueTracker.h
@@ -25,7 +25,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/AST.h> // Needed for m_zero below.
 
-#include <map>
+#include <unordered_map>
 #include <set>
 
 namespace solidity::yul
@@ -47,7 +47,7 @@ public:
 	void operator()(VariableDeclaration const& _varDecl) override;
 	void operator()(Assignment const& _assignment) override;
 
-	std::map<YulName, Expression const*> const& values() const { return m_values; }
+	std::unordered_map<YulName, Expression const*> const& values() const { return m_values; }
 	Expression const* value(YulName _name) const { return m_values.at(_name); }
 
 	static std::set<YulName> ssaVariables(Block const& _ast);
@@ -58,7 +58,7 @@ private:
 	/// Special expression whose address will be used in m_values.
 	/// YulName does not need to be reset because SSAValueTracker is short-lived.
 	Expression const m_zero{Literal{{}, LiteralKind::Number, LiteralValue(u256{0})}};
-	std::map<YulName, Expression const*> m_values;
+	std::unordered_map<YulName, Expression const*> m_values;
 };
 
 }

--- a/libyul/optimiser/SSAValueTracker.h
+++ b/libyul/optimiser/SSAValueTracker.h
@@ -25,7 +25,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/AST.h> // Needed for m_zero below.
 
-#include <unordered_map>
+#include <libsolutil/UnorderedContainers.h>
 #include <set>
 
 namespace solidity::yul
@@ -47,7 +47,7 @@ public:
 	void operator()(VariableDeclaration const& _varDecl) override;
 	void operator()(Assignment const& _assignment) override;
 
-	std::unordered_map<YulName, Expression const*> const& values() const { return m_values; }
+	util::unordered_flat_map<YulName, Expression const*> const& values() const { return m_values; }
 	Expression const* value(YulName _name) const { return m_values.at(_name); }
 
 	static std::set<YulName> ssaVariables(Block const& _ast);
@@ -58,7 +58,7 @@ private:
 	/// Special expression whose address will be used in m_values.
 	/// YulName does not need to be reset because SSAValueTracker is short-lived.
 	Expression const m_zero{Literal{{}, LiteralKind::Number, LiteralValue(u256{0})}};
-	std::unordered_map<YulName, Expression const*> m_values;
+	util::unordered_flat_map<YulName, Expression const*> m_values;
 };
 
 }


### PR DESCRIPTION
## Description

This PR separates a change made initially in https://github.com/argotorg/solidity/pull/16459. It’s unrelated change and should be benchmarked in separation.

Comment asking for separation https://github.com/argotorg/solidity/pull/16459/changes#r3766579197

## AI Disclosure
- [x] No AI tools were used
