### PR TITLE
ci: drop fastly mirror for arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1273,6 +1273,10 @@ jobs:
       - run:
           name: Install build dependencies
           command: |
+            # Drop the Fastly-cached mirror: its PoPs hold the package DB for many hours, so we get a
+            # DB referring to package versions that have already been pruned, and downloads can 404.
+            # pacman only fetches the DB from the first mirror, leaving geo.
+            sed -i '/fastly\.mirror\.pkgbuild\.com/d' /etc/pacman.d/mirrorlist
             pacman --noconfirm -Syu --noprogressbar --needed base-devel boost boost-libs cmake ccache git openssh tar
       - checkout
       - run_build
@@ -1439,6 +1443,10 @@ jobs:
       - run:
           name: Install runtime dependencies
           command: |
+            # Drop the Fastly-cached mirror: its PoPs hold the package DB for many hours, so we get a
+            # DB referring to package versions that have already been pruned, and downloads 404.
+            # pacman only fetches the DB from the first mirror, leaving geo.
+            sed -i '/fastly\.mirror\.pkgbuild\.com/d' /etc/pacman.d/mirrorlist
             pacman --noconfirm -Syu --noprogressbar --needed z3 git
       - soltest
 


### PR DESCRIPTION
we're currently running into problems with an out-of-sync db https://app.circleci.com/pipelines/gh/argotorg/solidity/43801/details?useNewPipelines=true&job=5de71618-b4f7-415b-b63b-557943244807&workflowId=a7fa5202-43d4-4977-af79-4aa2ca540ecb&buildNumber=2104485&jobType=build#step-101-