### PR TITLE
Yul Optimizer: Avoid full reference scan in DataFlowAnalyzer::clearValues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 * General: Remove support for the experimental Generic Solidity prototype (`pragma experimental solidity`).
 * SMTChecker: Emit a deprecation warning for the BMC engine.
 * SMTChecker: Support `block.slotnum`.
+* Yul Optimizer: Improve performance of `DataFlowAnalyzer::clearValues()`.
 
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -550,29 +550,6 @@ void iterateReplacingWindow(std::vector<T>& _vector, F const& _f, std::index_seq
 
 }
 
-/// Checks if two collections possess a non-empty intersection.
-/// Assumes that both inputs are sorted in ascending order.
-template<typename Collection1, typename Collection2>
-requires (
-	std::forward_iterator<std::ranges::iterator_t<Collection1>> &&
-	std::forward_iterator<std::ranges::iterator_t<Collection2>>
-)
-bool hasNonemptyIntersectionSorted(Collection1 const& _collection1, Collection2 const& _collection2)
-{
-	auto it1 = std::ranges::begin(_collection1);
-	auto it2 = std::ranges::begin(_collection2);
-	while (it1 != std::ranges::end(_collection1) && it2 != std::ranges::end(_collection2))
-	{
-		if (*it1 == *it2)
-			return true;
-		if (*it1 < *it2)
-			++it1;
-		else
-			++it2;
-	}
-	return false;
-}
-
 /// Function that iterates over the vector @param _vector,
 /// calling the function @param _f on sequences of @tparam N of its
 /// elements. If @param _f returns a vector, these elements are replaced by

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -266,7 +266,7 @@ void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Exp
 	std::vector const referencedVariablesSorted(referencedVariables.begin(), referencedVariables.end());
 	for (auto const& name: _variables)
 	{
-		m_state.sortedReferences[name] = referencedVariablesSorted;
+		setSortedReferences(name, referencedVariablesSorted);
 		if (!_isDeclaration)
 		{
 			// assignment to slot denoted by "name"
@@ -311,7 +311,7 @@ void DataFlowAnalyzer::popScope()
 	for (auto const& name: m_variableScopes.back().variables)
 	{
 		m_state.value.erase(name);
-		m_state.sortedReferences.erase(name);
+		eraseSortedReferences(name);
 	}
 	m_variableScopes.pop_back();
 }
@@ -346,20 +346,51 @@ void DataFlowAnalyzer::clearValues(std::set<YulName> const& _variablesToClear)
 			_variablesToClear.count(_item.second);
 	});
 
-	// Also clear variables that reference variables to be cleared.
-	std::set<YulName> referencingVariablesToClear;
-	std::vector const sortedVariablesToClear(_variablesToClear.begin(), _variablesToClear.end());
-	for (auto const& [referencingVariable, referencedVariables]: m_state.sortedReferences)
-		// instead of checking each variable in `referencedVariables`, we check if there is any intersection making use of the
-		// sortedness of the vectors, which can increase performance by up to 50% in pathological cases
-		if (hasNonemptyIntersectionSorted(referencedVariables, sortedVariablesToClear))
-			referencingVariablesToClear.emplace(referencingVariable);
+	// Also clear the variables directly referencing the ones to be cleared.
+	// Rather than scanning all of m_state.sortedReferences, look them up through the reverse index.
+	util::unordered_flat_set<YulName> variablesToClearWithReferencers(
+		_variablesToClear.begin(),
+		_variablesToClear.end()
+	);
+	for (YulName const& variableToClear: _variablesToClear)
+		if (auto const* referencers = util::valueOrNullptr(m_state.reverseReferences, variableToClear))
+			variablesToClearWithReferencers.insert(referencers->begin(), referencers->end());
 
 	// Clear the value and update the reference relation.
-	for (auto const& name: _variablesToClear + referencingVariablesToClear)
+	// The erasures are independent of each other, so their order cannot affect the resulting state.
+	for (YulName const& name: variablesToClearWithReferencers)
 	{
 		m_state.value.erase(name);
-		m_state.sortedReferences.erase(name);
+		eraseSortedReferences(name);
+	}
+}
+
+void DataFlowAnalyzer::setSortedReferences(
+	YulName _referencer,
+	std::vector<YulName> const& _referencedVariablesSorted
+)
+{
+	eraseSortedReferences(_referencer);
+	for (YulName const& referenced: _referencedVariablesSorted)
+		m_state.reverseReferences[referenced].insert(_referencer);
+	m_state.sortedReferences[_referencer] = _referencedVariablesSorted;
+}
+
+void DataFlowAnalyzer::eraseSortedReferences(YulName _referencer)
+{
+	auto const* previouslyReferenced = util::valueOrNullptr(m_state.sortedReferences, _referencer);
+	if (previouslyReferenced)
+	{
+		for (YulName const& referenced: *previouslyReferenced)
+		{
+			auto it = m_state.reverseReferences.find(referenced);
+			yulAssert(it != m_state.reverseReferences.end());
+			size_t const erasedBackPointers = it->second.erase(_referencer);
+			yulAssert(erasedBackPointers == 1);
+			if (it->second.empty())
+				m_state.reverseReferences.erase(it);
+		}
+		m_state.sortedReferences.erase(_referencer);
 	}
 }
 

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -31,6 +31,7 @@
 
 #include <libsolutil/Numeric.h>
 #include <libsolutil/Common.h>
+#include <libsolutil/UnorderedContainers.h>
 
 #include <map>
 #include <set>
@@ -122,6 +123,9 @@ protected:
 
 	/// Clears information about the values assigned to the given variables,
 	/// for example at points where control flow is merged.
+	/// The cached values and outgoing references of the variables directly referencing them are
+	/// cleared as well, while storage, memory and keccak knowledge is cleared only for entries
+	/// involving one of the given variables.
 	void clearValues(std::set<YulName> const& _variablesToClear);
 
 	virtual void assignValue(YulName _variable, Expression const* _value);
@@ -168,6 +172,18 @@ protected:
 	std::map<FunctionHandle, SideEffects> m_functionSideEffects;
 
 private:
+	/// Replaces the outgoing references of @a _referencer, i.e. the variables that the expression
+	/// currently assigned to it refers to, and keeps m_state.reverseReferences in sync.
+	/// @a _referencedVariablesSorted must be sorted and duplicate-free.
+	void setSortedReferences(
+		YulName _referencer,
+		std::vector<YulName> const& _referencedVariablesSorted
+	);
+
+	/// Removes @a _referencer's entry from m_state.sortedReferences, if any, together with the
+	/// corresponding back-pointers in m_state.reverseReferences.
+	void eraseSortedReferences(YulName _referencer);
+
 	struct Environment
 	{
 		util::unordered_flat_map<YulName, YulName> storage;
@@ -179,9 +195,17 @@ private:
 	{
 		/// Current values of variables, always movable.
 		std::map<YulName, AssignedValue> value;
-		/// m_references[a].contains(b) <=> the current expression assigned to a references b
-		/// The mapped vectors _must always_ be sorted
+		/// sortedReferences[a].contains(b) <=> the current expression assigned to a references b
+		/// The mapped vectors _must always_ be duplicate-free, which eraseSortedReferences()
+		/// relies on to remove exactly one back-pointer per entry, and sorted, which is what
+		/// the sortedReferences() accessor gives its callers.
 		util::unordered_flat_map<YulName, std::vector<YulName>> sortedReferences;
+		/// Reverse index of sortedReferences:
+		/// reverseReferences[b].contains(a) <=> sortedReferences[a].contains(b)
+		/// Kept in sync by setSortedReferences() and eraseSortedReferences(), so that
+		/// clearValues() can find the variables directly referencing a given variable
+		/// without scanning the whole of sortedReferences.
+		util::unordered_flat_map<YulName, util::unordered_flat_set<YulName>> reverseReferences;
 
 		Environment environment;
 	};


### PR DESCRIPTION
## Description

Large codebases pay double-digit minutes per `--via-ir` build (#13050, #15141); on pathological shapes this scan dominates (#13822). `DataFlowAnalyzer::clearValues()` has to find the variables whose currently assigned expression references one being cleared; it did so by scanning all of `m_state.sortedReferences`, a walk over every tracked variable per call. This maintains the inverse relation (`reverseReferences`), so referencers are looked up directly.

Both directions are written only by two private helpers; removing a forward edge asserts that exactly one matching reverse edge is removed. `hasNonemptyIntersectionSorted()` served only the scan and goes with it.

| | argotorg:develop | this PR | measured |
|---|---|---|---|
| Basic operation | one `YulName` key inspection: a comparison in the sorted scan | one `YulName` key inspection: a hash probe | constants differ; priced below |
| Reference-bookkeeping time, cumulative worst case | `O(n³)` | expected `O(n²)` | **-34.0%** on `chains.sol --via-ir`, **+2.4%** on `verifier.sol` |
| Asymptotic auxiliary space | `O(n²)` | `O(n²)`, one reverse edge per forward edge | peak resident set size (RSS) +0.4% to 1.0% |

`n` is the abstract syntax tree node count of one function body. The cubic requires `handleAssignment` storing one wide reference vector for many assigned names; typical code sits far from it. Only `chains.sol --via-ir` below resolves; its shape, long chains of narrow assignments, is cumulatively quadratic before, expected linear after.

| configuration | argotorg:develop | this PR | |
|---|---:|---:|---|
| `chains.sol --optimize --via-ir` | 1766.7 ms | 1166.2 ms | **-34.0%** |
| `chains.sol --optimize` | 48.2 ms | 48.4 ms | within noise |
| `OptimizorClub.sol --optimize --via-ir` | 583.7 ms | 590.4 ms | within noise |
| `verifier.sol --optimize --via-ir` | 117.1 ms | 119.9 ms | **+2.4%** |

Medians of 22 counterbalanced paired observations per cell, Release builds, macOS arm64; laptop numbers, a dedicated-machine run is welcome. The last row prices maintaining the index: head slower in all 22 pairs. Timings compare parent `f5395d3bc` against `d8acc5ad8`, whose `DataFlowAnalyzer.cpp` is byte-identical to head.

No intended change to compiler output: `bytecode_size` is identical in all 58 project/preset cells of the `c_ext_benchmarks` artifacts ([head](https://circleci.com/gh/argotorg/solidity/2106953) against [parent](https://circleci.com/gh/argotorg/solidity/2105950)), and local metadata-stripped (`--no-cbor-metadata`) bytecode is byte-identical in all four configurations. The gas columns move for unrelated reasons: deployment-gas deltas are mostly exact multiples of 12, the zero/nonzero calldata cost gap from the commit-specific metadata hash, and method-gas deltas appear even under `legacy-no-optimize`, where the Yul optimizer never runs; the comparison is mine.

No new test: the suite detects both directions of the relation breaking. Omitting the reverse-edge insertion fails 221 of 651 `yulOptimizerTests`; omitting its removal fails exactly `commonSubexpressionEliminator/clear_not_needed`.

**Prior art.** Same approach as #14112, closed as inconclusive rather than rejected; #13822 carries no desirability label and may want triage first. @cameel's open question there, whether one pathological contract justifies the cost, stands. New since then: #14112's 23.16 s to 10.52 s reproduces on a second toolchain (1766.7 to 1166.2 ms here); the regression cost is measured (+2.4%, RSS +0.4% to 1.0%); the diff is narrower (+70/-37 against +135/-8).

Reproduction: [raw benchmark data gist](https://gist.github.com/0xferit/53a91b3373e3104b9fffdb515b792983) with build commands (`raw.txt`), timing driver (`bench.py`), mutation commands (`mutations.md`), all timings, RSS readings and output hashes.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

Claude Code: profiling, implementation, benchmarks, test runs, and the first draft of this description. OpenAI Codex: independent review of the implementation, the benchmark claims and the reproduction commands, which is where several corrections above came from. I reviewed, understood and verified all of it myself.
