### PR TITLE
Yul Optimizer: Use flat hash containers in DataFlowAnalyzer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Compiler Features:
 * Yul Optimizer: `LoopInvariantCodeMotion` can now move expressions depending on function parameters out of loops.
 * Yul Optimizer: `UnusedStoreEliminator` can now recognize redundant memory and storage operations whose start offset or length is a function parameter.
 * Yul Optimizer: Remove the ineffective elimination of unused `returndatacopy()` operations in simple cases from UnusedStoreEliminator.
+* Yul Optimizer: Use a hash-based container instead of an ordered tree for `DataFlowAnalyzer`'s per-variable value and scope maps, speeding up compilation of code with many variables.
 
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -107,7 +107,7 @@ void DataFlowAnalyzer::operator()(VariableDeclaration& _varDecl)
 	std::set<YulName> names;
 	for (auto const& var: _varDecl.variables)
 		names.emplace(var.name);
-	m_variableScopes.back().variables += names;
+	m_variableScopes.back().variables.insert(names.begin(), names.end());
 
 	if (_varDecl.value)
 	{

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -177,7 +177,7 @@ private:
 	struct State
 	{
 		/// Current values of variables, always movable.
-		std::map<YulName, AssignedValue> value;
+		util::unordered_flat_map<YulName, AssignedValue> value;
 		/// m_references[a].contains(b) <=> the current expression assigned to a references b
 		/// The mapped vectors _must always_ be sorted
 		util::unordered_flat_map<YulName, std::vector<YulName>> sortedReferences;
@@ -212,7 +212,7 @@ protected:
 	struct Scope
 	{
 		explicit Scope(bool _isFunction): isFunction(_isFunction) {}
-		std::set<YulName> variables;
+		util::unordered_flat_set<YulName> variables;
 		bool isFunction;
 	};
 	/// Special expression whose address will be used in m_value.

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -105,7 +105,6 @@ public:
 	/// @returns the current value of the given variable, if known - always movable.
 	AssignedValue const* variableValue(YulName _variable) const { return util::valueOrNullptr(m_state.value, _variable); }
 	std::vector<YulName> const* sortedReferences(YulName _variable) const { return util::valueOrNullptr(m_state.sortedReferences, _variable); }
-	std::map<YulName, AssignedValue> const& allValues() const { return m_state.value; }
 	std::optional<YulName> storageValue(YulName _key) const;
 	std::optional<YulName> memoryValue(YulName _key) const;
 	std::optional<YulName> keccakValue(YulName _start, YulName _length) const;


### PR DESCRIPTION
## Description

Converts `DataFlowAnalyzer::State::value` and `Scope::variables` from red-black trees to `util::unordered_flat_map`/`unordered_flat_set`, matching `sortedReferences` and the `Environment` maps in the same file. Both are touched on essentially every variable reference in every `DataFlowAnalyzer`-derived pass.

Also removes `allValues()`, unused since 40342264c and the only thing handing out `State::value` whole (@msooseth's catch).

Ordering cannot reach the output: `State::value` is never iterated and, with `allValues()` gone, never exposed; `Scope::variables` is iterated only in `popScope()`, where the erasures commute; nothing keeps an `AssignedValue const*` across a mutation of the map owning it, so rehash invalidation is unreachable; the hash is `YulName`'s content-based FNV value and the tables are unseeded.

`SSAValueTracker::m_values`, the third container originally here, reached `develop` as fe6e2e840/d3a76c38e, so the rebase drops it and the figures are re-collected against current `develop`.

| configuration | `develop` | this PR | |
|---|---:|---:|---|
| `chains.sol --optimize --via-ir` | 1786.2 | 1652.0 ms | **-7.5%** |
| `chains.sol --optimize` | 49.7 | 47.5 ms | **-4.3%** |
| `OptimizorClub.sol --optimize --via-ir` | 590.9 | 560.0 ms | **-5.2%** |
| `verifier.sol --optimize --via-ir` | 119.8 | 115.5 ms | **-3.6%** |

Medians of 30 counterbalanced pairs per cell over baseline 57e108905, Release, macOS arm64, busy laptop; head faster in 117 of 120 pairs, peak RSS within -1.6% to +1.8%. Rebuilding after the removal gives a byte-identical `solc`, so these describe the head. Metadata-stripped bytecode matches `develop` in all four configurations, re-checked against 2381271ab after the rebase. [Raw data](https://gist.github.com/0xferit/8ceb2e2eb05d42200a1c2c41d23f276a).

The Changelog entry sits under 0.8.38 for now; drop it if your benchmarks do not justify one.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

Claude Code: profiling, benchmarks, adversarial verification of the order-insensitivity, pointer-stability and determinism claims, and the first draft of this description. I reviewed, understood and verified all of it myself.

