### PR TITLE
Fix Docs: Typo from Frozeable to Freezable

### DIFF
--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -372,7 +372,7 @@ The full contract
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.7.0 <0.9.0;
 
-    contract Frozeable {
+    contract Freezable {
         bool private _frozen = false;
 
         modifier notFrozen() {
@@ -385,7 +385,7 @@ The full contract
         }
     }
 
-    contract SimplePaymentChannel is Frozeable {
+    contract SimplePaymentChannel is Freezable {
         address payable public sender;    // The account sending payments.
         address payable public recipient; // The account receiving the payments.
         uint256 public expiration;        // Timeout in case the recipient never closes.


### PR DESCRIPTION
## Description

Fixes a typo in the `SimplePaymentChannel` example in `docs/examples/micropayment.rst`:
the helper contract `Frozeable` is renamed to the correct spelling `Freezable`,
in both the contract definition and the `is` clause of `SimplePaymentChannel`.

The same page already uses the correct spelling `Freezable` in the earlier
`ReceiverPays` example, so this change fixes an internal inconsistency within
the document. The rename is purely cosmetic — it does not alter the example's
behavior.

Note: the "open in Remix" link for this example also contains the old spelling
in its encoded payload and may need to be regenerated.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

- [ ] No AI tools were used

AI (Claude) was used only to confirm the typo appears in the current
official documentation and to check that the corrected spelling matches
the convention used elsewhere on the same page. The typo was discovered
and fixed independently.