### PR TITLE
SSA CFG: Fix shuffler cycle caused by overeager pop of spilled top

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -951,11 +951,12 @@ private:
 		yulAssert(!_stack.empty(), "Stack is empty, can't shrink");
 
 		StackOffset const stackTop{_stack.size() - 1};
-		// pop top if it is junk (ie actual junk, not in args, not in live out) or spilled
+		// pop top if it is junk (ie actual junk, not in args, not in live out)
+		// a spilled top that is still required is deliberately not popped eagerly:
+	    // an eager pop just forces a reload of the same value (potentially oscillating against the reload in fixArgsSlot)
 		if (
 			_stack[stackTop].isJunk() ||
-			(!_state.requiredInArgs(_stack[stackTop]) && !_state.requiredInTail(_stack[stackTop])) ||
-			_state.slotIsSpilled(_stack[stackTop])
+			(!_state.requiredInArgs(_stack[stackTop]) && !_state.requiredInTail(_stack[stackTop]))
 		)
 		{
 			_stack.pop();
@@ -1017,16 +1018,16 @@ private:
 				bool const isJunk = slot.isJunk();
 				bool const hasSurplus = _state.count(slot) > _state.targetMinCount(slot);
 				bool const hasReachableDuplicate = _state.countReachable(slot) > 1;
-				bool const freelyGeneratable = canBeFreelyGenerated(slot);
+				bool const regenerable = _state.slotCanBeLoadedOrPushed(slot);
 				bool const isLit = slot.isLiteralValue();
 
 				if (isJunk && notInPosition)
 					return 5;
-				if (freelyGeneratable && !isLit && notInPosition)
+				if (regenerable && !isLit && notInPosition)
 					return 4;
 				if (hasSurplus)
 					return 3;
-				if (freelyGeneratable)
+				if (regenerable)
 					return 2;
 				if (hasReachableDuplicate)
 					return 1;

--- a/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
@@ -131,37 +131,37 @@
 // calldataload\l\
 // [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35]\l\
 // \l\
-// [ReturnLabel[1], v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v35, v1]\l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v1, v35, v1]\l\
 // sstore\l\
-// [ReturnLabel[1], v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v1]\l\
 // \l\
-// [ReturnLabel[1], v31, v29, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v33, v3]\l\
+// [ReturnLabel[1], v31, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v33, v3]\l\
 // sstore\l\
-// [ReturnLabel[1], v31, v29, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
+// [ReturnLabel[1], v31, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
 // \l\
-// [ReturnLabel[1], v27, v29, v25, v7, v9, v11, v13, v15, v17, v19, v21, v23, v31, v5]\l\
+// [ReturnLabel[1], v29, v1, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v31, v5]\l\
 // sstore\l\
-// [ReturnLabel[1], v27, v29, v25, v7, v9, v11, v13, v15, v17, v19, v21, v23]\l\
+// [ReturnLabel[1], v29, v1, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
 // \l\
-// [ReturnLabel[1], v27, v23, v25, v21, v9, v11, v13, v15, v17, v19, v29, v7]\l\
+// [ReturnLabel[1], v25, v1, v27, v23, v9, v11, v13, v15, v17, v19, v21, v29, v7]\l\
 // sstore\l\
-// [ReturnLabel[1], v27, v23, v25, v21, v9, v11, v13, v15, v17, v19]\l\
+// [ReturnLabel[1], v25, v1, v27, v23, v9, v11, v13, v15, v17, v19, v21]\l\
 // \l\
-// [ReturnLabel[1], v19, v23, v25, v21, v17, v11, v13, v15, v27, v9]\l\
+// [ReturnLabel[1], v25, v1, v21, v23, v19, v11, v13, v15, v17, v27, v9]\l\
 // sstore\l\
-// [ReturnLabel[1], v19, v23, v25, v21, v17, v11, v13, v15]\l\
+// [ReturnLabel[1], v25, v1, v21, v23, v19, v11, v13, v15, v17]\l\
 // \l\
-// [ReturnLabel[1], v19, v23, v15, v21, v17, v13, v25, v11]\l\
+// [ReturnLabel[1], v17, v1, v21, v23, v19, v15, v13, v25, v11]\l\
 // sstore\l\
-// [ReturnLabel[1], v19, v23, v15, v21, v17, v13]\l\
+// [ReturnLabel[1], v17, v1, v21, v23, v19, v15, v13]\l\
 // \l\
-// [ReturnLabel[1], v19, v17, v15, v21, v23, v13]\l\
+// [ReturnLabel[1], v17, v1, v21, v15, v19, v23, v13]\l\
 // sstore\l\
-// [ReturnLabel[1], v19, v17, v15, v21]\l\
+// [ReturnLabel[1], v17, v1, v21, v15, v19]\l\
 // \l\
-// [ReturnLabel[1], v19, v17, v21, v15]\l\
+// [ReturnLabel[1], v17, v19, v21, v15]\l\
 // sstore\l\
-// [ReturnLabel[1], v19, v17]\l\
+// [ReturnLabel[1], v17, v19]\l\
 // \l\
 // [ReturnLabel[1], v19, v17]\l\
 // sstore\l\

--- a/test/libyul/ssa/stackShuffler/spill_to_pop_deep_junk.stack
+++ b/test/libyul/ssa/stackShuffler/spill_to_pop_deep_junk.stack
@@ -5,22 +5,25 @@ targetStackTop: [v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v1
 //             |      0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19 |     20
 //             +-------------------------------------------------------------------------------------------------------------------------------------------- +-------
 //    (initial)|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19 |    v20
-//          POP|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19
-//          POP|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18
-//          POP|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
-//        SWAP1|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17    v16
-//        SWAP2|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v16    v17    v15
-//        SWAP3|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v15    v16    v17    v14
-//        SWAP4|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v14    v15    v16    v17    v13
-//        SWAP5|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v13    v14    v15    v16    v17    v12
-//        SWAP6|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v12    v13    v14    v15    v16    v17    v11
-//        SWAP7|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v11    v12    v13    v14    v15    v16    v17    v10
-//        SWAP8|      *     v1     v2     v3     v4     v5     v6     v7     v8    v10    v11    v12    v13    v14    v15    v16    v17     v9
-//        SWAP9|      *     v1     v2     v3     v4     v5     v6     v7     v9    v10    v11    v12    v13    v14    v15    v16    v17     v8
-//       SWAP10|      *     v1     v2     v3     v4     v5     v6     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v7
-//       SWAP11|      *     v1     v2     v3     v4     v5     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v6
-//       SWAP12|      *     v1     v2     v3     v4     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v5
-//       SWAP13|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v4
+//        SWAP1|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v20 |    v19
+//        SWAP2|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v19    v20 |    v18
+//        SWAP3|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v18    v19    v20 |    v17
+//        SWAP4|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17    v18    v19    v20 |    v16
+//        SWAP5|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v16    v17    v18    v19    v20 |    v15
+//        SWAP6|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v15    v16    v17    v18    v19    v20 |    v14
+//        SWAP7|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v14    v15    v16    v17    v18    v19    v20 |    v13
+//        SWAP8|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v13    v14    v15    v16    v17    v18    v19    v20 |    v12
+//        SWAP9|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v12    v13    v14    v15    v16    v17    v18    v19    v20 |    v11
+//       SWAP10|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |    v10
+//       SWAP11|      *     v1     v2     v3     v4     v5     v6     v7     v8    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v9
+//       SWAP12|      *     v1     v2     v3     v4     v5     v6     v7     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v8
+//       SWAP13|      *     v1     v2     v3     v4     v5     v6     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v7
+//       SWAP14|      *     v1     v2     v3     v4     v5     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v6
+//       SWAP15|      *     v1     v2     v3     v4     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v5
+//       SWAP16|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v4
+//          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20
+//          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19
+//          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18
 //          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
 //       SWAP15|      *    v17     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v1
 //       SWAP16|     v1    v17     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16      *

--- a/test/libyul/ssa/stackShuffler/spilled_arg_multiple_reload.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_arg_multiple_reload.stack
@@ -18,28 +18,10 @@ initialSpilledSet: {phi3, phi4, v6}
 //        SWAP3|     v0   phi3     v6     v6      *      *   lit2
 //          POP|     v0   phi3     v6     v6      *      *
 //         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          POP|     v0   phi3     v6     v6      *      *
-//         DUP5|     v0   phi3     v6     v6      *      *   phi3
-//          ...|
+//        SWAP2|     v0   phi3     v6     v6   phi3      *      *
+//          POP|     v0   phi3     v6     v6   phi3      *
+//         DUP2|     v0   phi3     v6     v6   phi3      *   phi3
 //             +-------------------------------------------------
 //     (target)|      *   phi3     v6     v6   phi3      *   phi3
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {phi3, phi4, v6}

--- a/test/libyul/ssa/stackShuffler/spilled_arg_multiple_reload.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_arg_multiple_reload.stack
@@ -1,0 +1,45 @@
+// all demanded args are already spilled (in memory, not on stack) and two of them are required at multiple arg
+// positions
+initial: [v0, JUNK, v1, lit2, JUNK]
+targetStackTop: [JUNK, phi3, v6, v6, phi3, JUNK, phi3]
+targetStackSize: 7
+allowSpilling: true
+initialSpilledSet: {phi3, phi4, v6}
+// ----
+//             |      0      1      2      3      4      5      6
+//             +-------------------------------------------------
+//    (initial)|     v0      *     v1   lit2      *
+//    PUSH phi3|     v0      *     v1   lit2      *   phi3
+//        SWAP4|     v0   phi3     v1   lit2      *      *
+//      PUSH v6|     v0   phi3     v1   lit2      *      *     v6
+//        SWAP4|     v0   phi3     v6   lit2      *      *     v1
+//          POP|     v0   phi3     v6   lit2      *      *
+//         DUP4|     v0   phi3     v6   lit2      *      *     v6
+//        SWAP3|     v0   phi3     v6     v6      *      *   lit2
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          POP|     v0   phi3     v6     v6      *      *
+//         DUP5|     v0   phi3     v6     v6      *      *   phi3
+//          ...|
+//             +-------------------------------------------------
+//     (target)|      *   phi3     v6     v6   phi3      *   phi3
+// Status: MaxIterationsReached
+// Spilled: {phi3, phi4, v6}

--- a/test/libyul/ssa/stackShuffler/spilled_dup.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_dup.stack
@@ -1,0 +1,45 @@
+// phi0 is on stack once and spilled, and is demanded at two arg positions. Spilled values have minCount 0, so any
+// copy on the stack reads as surplus and gets popped by shrinking before the second arg position can be filled.
+initial: [JUNK, JUNK, phi0]
+targetStackTop: [phi0, phi0]
+targetStackSize: 3
+allowSpilling: true
+initialSpilledSet: {phi0}
+// ----
+//             |      0 |      1      2
+//             +------- +--------------
+//    (initial)|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//    PUSH phi0|      * |      *   phi0
+//          POP|      * |      *
+//          ...|
+//             +------- +--------------
+//     (target)|     {} |   phi0   phi0
+// Status: MaxIterationsReached
+// Spilled: {phi0}

--- a/test/libyul/ssa/stackShuffler/spilled_dup.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_dup.stack
@@ -9,37 +9,10 @@ initialSpilledSet: {phi0}
 //             |      0 |      1      2
 //             +------- +--------------
 //    (initial)|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//    PUSH phi0|      * |      *   phi0
-//          POP|      * |      *
-//          ...|
+//        SWAP1|      * |   phi0      *
+//          POP|      * |   phi0
+//         DUP1|      * |   phi0   phi0
 //             +------- +--------------
 //     (target)|     {} |   phi0   phi0
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {phi0}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_growth.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_growth.stack
@@ -1,0 +1,45 @@
+// like spilled_reload_shrink_livelock but the stack has to grow. The spilled value v4 (absent from the stack) and
+// the literal lit7 are both demanded at arg positions.
+initial: [v0, phi1, phi2, JUNK, phi3]
+targetStackTop: [JUNK, JUNK, v4, lit7, JUNK, JUNK]
+targetStackSize: 6
+allowSpilling: true
+initialSpilledSet: {v4}
+// ----
+//             |      0      1      2      3      4      5
+//             +------------------------------------------
+//    (initial)|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          POP|     v0   phi1   phi2      *   phi3
+//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
+//          ...|
+//             +------------------------------------------
+//     (target)|      *      *     v4   lit7      *      *
+// Status: MaxIterationsReached
+// Spilled: {v4}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_growth.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_growth.stack
@@ -10,36 +10,11 @@ initialSpilledSet: {v4}
 //             +------------------------------------------
 //    (initial)|     v0   phi1   phi2      *   phi3
 //      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          POP|     v0   phi1   phi2      *   phi3
-//      PUSH v4|     v0   phi1   phi2      *   phi3     v4
-//          ...|
+//        SWAP3|     v0   phi1     v4      *   phi3   phi2
+//          POP|     v0   phi1     v4      *   phi3
+//    PUSH lit7|     v0   phi1     v4      *   phi3   lit7
+//        SWAP2|     v0   phi1     v4   lit7   phi3      *
 //             +------------------------------------------
 //     (target)|      *      *     v4   lit7      *      *
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {v4}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_shrink.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_shrink.stack
@@ -12,34 +12,11 @@ initialSpilledSet: {phi2}
 //          POP|   lit0      *   lit1      *      *
 //          POP|   lit0      *   lit1      *
 //    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          POP|   lit0      *   lit1      *
-//    PUSH phi2|   lit0      *   lit1      *   phi2
-//          ...|
+//        SWAP4|   phi2      *   lit1      *   lit0
+//          POP|   phi2      *   lit1      *
+//    PUSH lit3|   phi2      *   lit1      *   lit3
+//        SWAP2|   phi2      *   lit3      *   lit1
 //             +----------------------------------- +-------
 //     (target)|   phi2      *   lit3      *      * |
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {phi2}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_shrink.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_shrink.stack
@@ -1,0 +1,45 @@
+// a single spilled value (phi2, absent from the stack) and a pushable literal are demanded while the stack also has
+// to shrink by one
+initial: [lit0, JUNK, lit1, JUNK, JUNK, JUNK]
+targetStackTop: [phi2, JUNK, lit3, JUNK, JUNK]
+targetStackSize: 5
+allowSpilling: true
+initialSpilledSet: {phi2}
+// ----
+//             |      0      1      2      3      4 |      5
+//             +----------------------------------- +-------
+//    (initial)|   lit0      *   lit1      *      * |      *
+//          POP|   lit0      *   lit1      *      *
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          POP|   lit0      *   lit1      *
+//    PUSH phi2|   lit0      *   lit1      *   phi2
+//          ...|
+//             +----------------------------------- +-------
+//     (target)|   phi2      *   lit3      *      * |
+// Status: MaxIterationsReached
+// Spilled: {phi2}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_with_onstack_arg.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_with_onstack_arg.stack
@@ -17,29 +17,10 @@ initialSpilledSet: {phi4}
 //        SWAP4|   lit5   phi0   lit1      *   phi2
 //          POP|   lit5   phi0   lit1      *
 //    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//    PUSH phi4|   lit5   phi0   lit1      *   phi4
-//          POP|   lit5   phi0   lit1      *
-//          ...|
+//        SWAP1|   lit5   phi0   lit1   phi4      *
+//          POP|   lit5   phi0   lit1   phi4
+//         DUP1|   lit5   phi0   lit1   phi4   phi4
 //             +----------------------------------- +-------
 //     (target)|   lit5   phi0      *   phi4   phi4 |
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {phi4}

--- a/test/libyul/ssa/stackShuffler/spilled_reload_with_onstack_arg.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_reload_with_onstack_arg.stack
@@ -1,0 +1,45 @@
+// Test that mixes an on-stack arg (phi0, must move into position), a doubly-demanded spilled value (phi4, absent
+// from the stack) and a pushable literal
+initial: [phi0, JUNK, lit1, phi2, lit3, JUNK]
+targetStackTop: [lit5, phi0, JUNK, phi4, phi4]
+targetStackSize: 5
+allowSpilling: true
+initialSpilledSet: {phi4}
+// ----
+//             |      0      1      2      3      4 |      5
+//             +----------------------------------- +-------
+//    (initial)|   phi0      *   lit1   phi2   lit3 |      *
+//          POP|   phi0      *   lit1   phi2   lit3
+//          POP|   phi0      *   lit1   phi2
+//        SWAP3|   phi2      *   lit1   phi0
+//        SWAP2|   phi2   phi0   lit1      *
+//    PUSH lit5|   phi2   phi0   lit1      *   lit5
+//        SWAP4|   lit5   phi0   lit1      *   phi2
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//    PUSH phi4|   lit5   phi0   lit1      *   phi4
+//          POP|   lit5   phi0   lit1      *
+//          ...|
+//             +----------------------------------- +-------
+//     (target)|   lit5   phi0      *   phi4   phi4 |
+// Status: MaxIterationsReached
+// Spilled: {phi4}

--- a/test/libyul/ssa/stackShuffler/spilled_tail_reload.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_tail_reload.stack
@@ -10,36 +10,10 @@ initialSpilledSet: {phi3, phi4, phi5}
 //             +--------------------- +--------------
 //    (initial)|   phi0      *     v1 |   phi2
 //    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          POP|   phi0      *     v1 |   phi2
-//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
-//          ...|
+//        SWAP1|   phi0      *     v1 |   phi4   phi2
+//          POP|   phi0      *     v1 |   phi4
+//         DUP1|   phi0      *     v1 |   phi4   phi4
 //             +--------------------- +--------------
 //     (target)|              {phi3*} |   phi4   phi4
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {phi3, phi4, phi5}

--- a/test/libyul/ssa/stackShuffler/spilled_tail_reload.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_tail_reload.stack
@@ -1,0 +1,45 @@
+// the tail set demands a spilled value (phi3) that is absent from the stack, on top of doubly-demanded spilled args
+initial: [phi0, JUNK, v1, phi2]
+targetStackTop: [phi4, phi4]
+targetStackTailSet: {phi3}
+targetStackSize: 5
+allowSpilling: true
+initialSpilledSet: {phi3, phi4, phi5}
+// ----
+//             |      0      1      2 |      3      4
+//             +--------------------- +--------------
+//    (initial)|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          POP|   phi0      *     v1 |   phi2
+//    PUSH phi4|   phi0      *     v1 |   phi2   phi4
+//          ...|
+//             +--------------------- +--------------
+//     (target)|              {phi3*} |   phi4   phi4
+// Status: MaxIterationsReached
+// Spilled: {phi3, phi4, phi5}

--- a/test/libyul/ssa/stackShuffler/spilled_to_pop_deep_junk.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_to_pop_deep_junk.stack
@@ -6,22 +6,23 @@ targetStackTop: [v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v1
 //             |      0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19 |     20
 //             +-------------------------------------------------------------------------------------------------------------------------------------------- +-------
 //    (initial)|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19 |    v20
-//          POP|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19
-//        SWAP1|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v19    v18
-//        SWAP2|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v18    v19    v17
-//        SWAP3|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17    v18    v19    v16
-//        SWAP4|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v16    v17    v18    v19    v15
-//        SWAP5|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v15    v16    v17    v18    v19    v14
-//        SWAP6|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v14    v15    v16    v17    v18    v19    v13
-//        SWAP7|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v13    v14    v15    v16    v17    v18    v19    v12
-//        SWAP8|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v12    v13    v14    v15    v16    v17    v18    v19    v11
-//        SWAP9|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v11    v12    v13    v14    v15    v16    v17    v18    v19    v10
-//       SWAP10|      *     v1     v2     v3     v4     v5     v6     v7     v8    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v9
-//       SWAP11|      *     v1     v2     v3     v4     v5     v6     v7     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v8
-//       SWAP12|      *     v1     v2     v3     v4     v5     v6     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v7
-//       SWAP13|      *     v1     v2     v3     v4     v5     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v6
-//       SWAP14|      *     v1     v2     v3     v4     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v5
-//       SWAP15|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19     v4
+//        SWAP1|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v20 |    v19
+//        SWAP2|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v19    v20 |    v18
+//        SWAP3|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v18    v19    v20 |    v17
+//        SWAP4|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17    v18    v19    v20 |    v16
+//        SWAP5|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v16    v17    v18    v19    v20 |    v15
+//        SWAP6|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v15    v16    v17    v18    v19    v20 |    v14
+//        SWAP7|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v14    v15    v16    v17    v18    v19    v20 |    v13
+//        SWAP8|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v13    v14    v15    v16    v17    v18    v19    v20 |    v12
+//        SWAP9|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v12    v13    v14    v15    v16    v17    v18    v19    v20 |    v11
+//       SWAP10|      *     v1     v2     v3     v4     v5     v6     v7     v8     v9    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |    v10
+//       SWAP11|      *     v1     v2     v3     v4     v5     v6     v7     v8    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v9
+//       SWAP12|      *     v1     v2     v3     v4     v5     v6     v7     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v8
+//       SWAP13|      *     v1     v2     v3     v4     v5     v6     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v7
+//       SWAP14|      *     v1     v2     v3     v4     v5     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v6
+//       SWAP15|      *     v1     v2     v3     v4     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v5
+//       SWAP16|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |     v4
+//          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20
 //          POP|      *     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19
 //       SWAP16|      *     v1    v19     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18     v2
 //          POP|      *     v1    v19     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18

--- a/test/libyul/ssa/stackShuffler/spilled_top_and_tail.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_top_and_tail.stack
@@ -1,0 +1,46 @@
+// the spilled value v5 (absent from the stack) is demanded at both arg positions and is additionally live-out in
+// the tail set
+initial: [phi0, lit1]
+targetStackTop: [v5, v5]
+targetStackTailSet: {v5}
+targetStackSize: 3
+allowSpilling: true
+initialSpilledSet: {v5}
+// ----
+//             |      0 |      1      2
+//             +------- +--------------
+//    (initial)|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          POP|   phi0 |   lit1
+//      PUSH v5|   phi0 |   lit1     v5
+//          ...|
+//             +------- +--------------
+//     (target)|  {v5*} |     v5     v5
+// Status: MaxIterationsReached
+// Spilled: {v5}

--- a/test/libyul/ssa/stackShuffler/spilled_top_and_tail.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_top_and_tail.stack
@@ -11,36 +11,10 @@ initialSpilledSet: {v5}
 //             +------- +--------------
 //    (initial)|   phi0 |   lit1
 //      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          POP|   phi0 |   lit1
-//      PUSH v5|   phi0 |   lit1     v5
-//          ...|
+//        SWAP1|   phi0 |     v5   lit1
+//          POP|   phi0 |     v5
+//         DUP1|   phi0 |     v5     v5
 //             +------- +--------------
 //     (target)|  {v5*} |     v5     v5
-// Status: MaxIterationsReached
+// Status: Admissible
 // Spilled: {v5}


### PR DESCRIPTION
- `shrinkStack` eagerly popped any spilled stack top before trying the swap logic below. 
  When the spilled value was still demanded at an unfilled arg position, the pop just re-opened the demand, `fixArgsSlot` reloaded the same value, and the next shrink popped it again.
- Fix: the eager pop now only fires for junk and dead slots; a spilled top falls through to the swap logic, which places it directly into a demanded position (which the reload-side depth guards guarantee is swap-reachable). Since the reload only fires while an unfilled demand exists, and shrink swaps instead of popping in exactly that state, the pop and the reload can no longer alternate on the same state.
- Popping a spilled top stays possible, it's just demoted into the `shrinkPriority` cascade: `canBeFreelyGenerated` became `slotCanBeLoadedOrPushed` (meaning freely generatable or spilled), so a spilled slot scores as regenerable-out-of-position (4) or surplus (3) instead of being popped unconditionally first.