### PR TITLE
Infer modifier mutability per most derived contract

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 * View Pure Checker: Fix state mutability of `super` calls and modifier invocations being checked only against the contract declaring the function. Since both are re-resolved for each most derived contract, a `view` or `pure` function could reach a more mutable target there without being reported.
+* View Pure Checker: Fix state mutability of a modifier being inferred without regard to the most derived contract, so that a `super` call in its body could reach a more mutable function in a derived contract without the modifier being virtual or overridden.
 
 
 ### 0.8.36 (2026-07-09)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
+* View Pure Checker: Fix state mutability of `super` calls and modifier invocations being checked only against the contract declaring the function. Since both are re-resolved for each most derived contract, a `view` or `pure` function could reach a more mutable target there without being reported.
 
 
 ### 0.8.36 (2026-07-09)

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -129,9 +129,23 @@ private:
 bool ViewPureChecker::check()
 {
 	for (auto const& source: m_ast)
+		for (ContractDefinition const* contract: ASTNode::filteredNodes<ContractDefinition>(dynamic_cast<SourceUnit const&>(*source).nodes()))
+			for (ContractDefinition const* base: contract->annotation().linearizedBaseContracts)
+				m_derivedContracts[base].push_back(contract);
+
+	for (auto const& source: m_ast)
 		source->accept(*this);
 
 	return !m_errors;
+}
+
+std::vector<ContractDefinition const*> const& ViewPureChecker::currentDerivedContracts()
+{
+	static std::vector<ContractDefinition const*> const noContracts;
+
+	if (!m_currentFunction || !m_currentFunction->annotation().contract)
+		return noContracts;
+	return m_derivedContracts[m_currentFunction->annotation().contract];
 }
 
 bool ViewPureChecker::visit(ImportDirective const&)
@@ -352,6 +366,34 @@ void ViewPureChecker::endVisit(FunctionCall const& _functionCall)
 		dynamic_cast<FunctionType const&>(*_functionCall.expression().annotation().type).stateMutability(),
 		_functionCall.location()
 	);
+
+	// Everything below applies only to super calls.
+	auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression());
+	if (!memberAccess || *memberAccess->annotation().requiredLookup != VirtualLookup::Super)
+		return;
+
+	// The call resolves to a different function in each contract inheriting the current one.
+	for (ContractDefinition const* derived: currentDerivedContracts())
+	{
+		FunctionDefinition const* resolved = ASTNode::resolveFunctionCall(_functionCall, derived);
+		if (
+			!resolved ||
+			resolved == memberAccess->annotation().referencedDeclaration ||
+			resolved->stateMutability() <= m_currentFunction->stateMutability()
+		)
+			continue;
+
+		m_errorReporter.typeError(
+			7898_error,
+			derived->location(),
+			"\"" + m_currentFunction->annotation().contract->name() + "." + m_currentFunction->name() +
+			"\" is declared \"" + stateMutabilityToString(m_currentFunction->stateMutability()) +
+			"\", but in this contract its super call resolves to \"" +
+			resolved->annotation().contract->name() + "." + resolved->name() +
+			"\", which is \"" + stateMutabilityToString(resolved->stateMutability()) + "\"."
+		);
+		m_errors = true;
+	}
 }
 
 bool ViewPureChecker::visit(MemberAccess const& _memberAccess)
@@ -465,6 +507,29 @@ void ViewPureChecker::endVisit(ModifierInvocation const& _modifier)
 	{
 		MutabilityAndLocation const& mutAndLocation = modifierMutability(*mod);
 		reportMutability(mutAndLocation.mutability, _modifier.location(), mutAndLocation.location);
+
+		// The modifier may be overridden in each contract inheriting the current one.
+		for (ContractDefinition const* derived: currentDerivedContracts())
+		{
+			ModifierDefinition const& resolved = mod->resolveVirtual(*derived);
+			if (&resolved == mod)
+				continue;
+
+			StateMutability mutability = modifierMutability(resolved).mutability;
+			if (mutability <= m_currentFunction->stateMutability())
+				continue;
+
+			m_errorReporter.typeError(
+				1614_error,
+				resolved.location(),
+				"This modifier overrides \"" + mod->name() + "\" with state mutability \"" +
+				stateMutabilityToString(mutability) + "\", but \"" +
+				m_currentFunction->annotation().contract->name() + "." + m_currentFunction->name() +
+				"\", which uses it, is declared \"" +
+				stateMutabilityToString(m_currentFunction->stateMutability()) + "\"."
+			);
+			m_errors = true;
+		}
 	}
 	else
 		solAssert(dynamic_cast<ContractDefinition const*>(_modifier.name().annotation().referencedDeclaration), "");

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -182,6 +182,17 @@ void ViewPureChecker::endVisit(FunctionDefinition const& _funDef)
 	m_currentFunction = nullptr;
 }
 
+bool ViewPureChecker::visit(ContractDefinition const& _contract)
+{
+	m_mostDerivedContract = &_contract;
+	return true;
+}
+
+void ViewPureChecker::endVisit(ContractDefinition const&)
+{
+	m_mostDerivedContract = nullptr;
+}
+
 bool ViewPureChecker::visit(ModifierDefinition const& _modifier)
 {
 	solAssert(m_currentFunction == nullptr, "");
@@ -192,7 +203,7 @@ bool ViewPureChecker::visit(ModifierDefinition const& _modifier)
 void ViewPureChecker::endVisit(ModifierDefinition const& _modifierDef)
 {
 	solAssert(m_currentFunction == nullptr, "");
-	m_inferredMutability[&_modifierDef] = std::move(m_bestMutabilityAndLocation);
+	m_inferredMutability[{&_modifierDef, m_mostDerivedContract}] = std::move(m_bestMutabilityAndLocation);
 }
 
 void ViewPureChecker::endVisit(Identifier const& _identifier)
@@ -319,22 +330,27 @@ void ViewPureChecker::reportMutability(
 }
 
 ViewPureChecker::MutabilityAndLocation const& ViewPureChecker::modifierMutability(
-	ModifierDefinition const& _modifier
+	ModifierDefinition const& _modifier,
+	ContractDefinition const* _mostDerivedContract
 )
 {
-	if (!m_inferredMutability.count(&_modifier))
+	auto key = std::make_pair(&_modifier, _mostDerivedContract);
+	if (!m_inferredMutability.count(key))
 	{
 		MutabilityAndLocation bestMutabilityAndLocation{};
 		FunctionDefinition const* currentFunction = nullptr;
+		ContractDefinition const* mostDerivedContract = _mostDerivedContract;
 		std::swap(bestMutabilityAndLocation, m_bestMutabilityAndLocation);
 		std::swap(currentFunction, m_currentFunction);
+		std::swap(mostDerivedContract, m_mostDerivedContract);
 
 		_modifier.accept(*this);
 
 		std::swap(bestMutabilityAndLocation, m_bestMutabilityAndLocation);
 		std::swap(currentFunction, m_currentFunction);
+		std::swap(mostDerivedContract, m_mostDerivedContract);
 	}
-	return m_inferredMutability.at(&_modifier);
+	return m_inferredMutability.at(key);
 }
 
 void ViewPureChecker::reportFunctionCallMutability(StateMutability _mutability, langutil::SourceLocation const& _location)
@@ -371,6 +387,15 @@ void ViewPureChecker::endVisit(FunctionCall const& _functionCall)
 	auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression());
 	if (!memberAccess || *memberAccess->annotation().requiredLookup != VirtualLookup::Super)
 		return;
+
+	// No enclosing function means a modifier body: feed the target's mutability into the inference.
+	if (!m_currentFunction)
+	{
+		if (m_mostDerivedContract)
+			if (FunctionDefinition const* resolved = ASTNode::resolveFunctionCall(_functionCall, m_mostDerivedContract))
+				reportFunctionCallMutability(resolved->stateMutability(), _functionCall.location());
+		return;
+	}
 
 	// The call resolves to a different function in each contract inheriting the current one.
 	for (ContractDefinition const* derived: currentDerivedContracts())
@@ -505,25 +530,30 @@ void ViewPureChecker::endVisit(ModifierInvocation const& _modifier)
 {
 	if (ModifierDefinition const* mod = dynamic_cast<decltype(mod)>(_modifier.name().annotation().referencedDeclaration))
 	{
-		MutabilityAndLocation const& mutAndLocation = modifierMutability(*mod);
-		reportMutability(mutAndLocation.mutability, _modifier.location(), mutAndLocation.location);
+		MutabilityAndLocation const& mutAndLocation = modifierMutability(*mod, m_mostDerivedContract);
+		StateMutability baseMutability = mutAndLocation.mutability;
+		reportMutability(baseMutability, _modifier.location(), mutAndLocation.location);
 
-		// The modifier may be overridden in each contract inheriting the current one.
+		// The modifier may be overridden, or its `super` calls may resolve elsewhere, in each inheriting contract.
 		for (ContractDefinition const* derived: currentDerivedContracts())
 		{
 			ModifierDefinition const& resolved = mod->resolveVirtual(*derived);
-			if (&resolved == mod)
+			StateMutability mutability = modifierMutability(resolved, derived).mutability;
+			// Anything this loose was already reported against the base above.
+			if (mutability <= baseMutability)
 				continue;
 
-			StateMutability mutability = modifierMutability(resolved).mutability;
+			// Raise the mutability we suggest to the user, then skip if the declaration already permits it.
+			if (mutability > m_bestMutabilityAndLocation.mutability)
+				m_bestMutabilityAndLocation = {mutability, resolved.location()};
 			if (mutability <= m_currentFunction->stateMutability())
 				continue;
 
 			m_errorReporter.typeError(
 				1614_error,
 				resolved.location(),
-				"This modifier overrides \"" + mod->name() + "\" with state mutability \"" +
-				stateMutabilityToString(mutability) + "\", but \"" +
+				"Modifier \"" + mod->name() + "\" has state mutability \"" +
+				stateMutabilityToString(mutability) + "\" in \"" + derived->name() + "\", but \"" +
 				m_currentFunction->annotation().contract->name() + "." + m_currentFunction->name() +
 				"\", which uses it, is declared \"" +
 				stateMutabilityToString(m_currentFunction->stateMutability()) + "\"."

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -53,6 +53,8 @@ private:
 
 	bool visit(ImportDirective const&) override;
 
+	bool visit(ContractDefinition const& _contract) override;
+	void endVisit(ContractDefinition const& _contract) override;
 	bool visit(FunctionDefinition const& _funDef) override;
 	void endVisit(FunctionDefinition const& _funDef) override;
 	void endVisit(BinaryOperation const& _binaryOperation) override;
@@ -78,8 +80,13 @@ private:
 
 	void reportFunctionCallMutability(StateMutability _mutability, langutil::SourceLocation const& _location);
 
-	/// Determines the mutability of modifier if not already cached.
-	MutabilityAndLocation const& modifierMutability(ModifierDefinition const& _modifier);
+	/// Determines the mutability of modifier as seen from @a _mostDerivedContract if not already
+	/// cached. A super call in the body resolves differently in each contract, so the mutability
+	/// belongs to the pair, not to the modifier alone.
+	MutabilityAndLocation const& modifierMutability(
+		ModifierDefinition const& _modifier,
+		ContractDefinition const* _mostDerivedContract
+	);
 
 	/// @returns the contracts @a m_currentFunction can be inherited into, empty if it is not a member of a contract.
 	std::vector<ContractDefinition const*> const& currentDerivedContracts();
@@ -90,7 +97,10 @@ private:
 	bool m_errors = false;
 	MutabilityAndLocation m_bestMutabilityAndLocation = MutabilityAndLocation{StateMutability::Payable, langutil::SourceLocation()};
 	FunctionDefinition const* m_currentFunction = nullptr;
-	std::map<ModifierDefinition const*, MutabilityAndLocation> m_inferredMutability;
+	/// Contract supplying the linearization that `super` calls are resolved against.
+	ContractDefinition const* m_mostDerivedContract = nullptr;
+	/// Inferred mutability of each modifier, as seen from a given most derived contract.
+	std::map<std::pair<ModifierDefinition const*, ContractDefinition const*>, MutabilityAndLocation> m_inferredMutability;
 	/// Reverse of the linearizations: every contract mapped to the contracts that inherit from it.
 	std::map<ContractDefinition const*, std::vector<ContractDefinition const*>> m_derivedContracts;
 };

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace solidity::langutil
 {
@@ -80,6 +81,9 @@ private:
 	/// Determines the mutability of modifier if not already cached.
 	MutabilityAndLocation const& modifierMutability(ModifierDefinition const& _modifier);
 
+	/// @returns the contracts @a m_currentFunction can be inherited into, empty if it is not a member of a contract.
+	std::vector<ContractDefinition const*> const& currentDerivedContracts();
+
 	std::vector<std::shared_ptr<ASTNode>> const& m_ast;
 	langutil::ErrorReporter& m_errorReporter;
 
@@ -87,6 +91,8 @@ private:
 	MutabilityAndLocation m_bestMutabilityAndLocation = MutabilityAndLocation{StateMutability::Payable, langutil::SourceLocation()};
 	FunctionDefinition const* m_currentFunction = nullptr;
 	std::map<ModifierDefinition const*, MutabilityAndLocation> m_inferredMutability;
+	/// Reverse of the linearizations: every contract mapped to the contracts that inherit from it.
+	std::map<ContractDefinition const*, std::vector<ContractDefinition const*>> m_derivedContracts;
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
@@ -1,7 +1,7 @@
 abstract contract A {
 	bool s;
 
-	function f() public view mod {
+	function f() public mod {
 		assert(s); // holds for C, but fails for B
 	}
 	modifier mod() virtual;
@@ -23,7 +23,8 @@ contract C is B {
 // ====
 // SMTEngine: all
 // ----
-// Warning 8429: (113-136): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 8429: (159-213): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 6328: (66-75): CHC: Assertion violation happens here.\nCounterexample:\ns = false\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
+// Warning 8429: (108-131): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (154-208): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 2018: (33-106): Function state mutability can be restricted to view
+// Warning 6328: (61-70): CHC: Assertion violation happens here.\nCounterexample:\ns = false\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
 // Warning 3993: The BMC engine of the SMTChecker is deprecated and will be removed in a future release. Please use the CHC engine instead.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
@@ -25,6 +25,5 @@ contract C is B {
 // ----
 // Warning 8429: (108-131): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 8429: (154-208): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 2018: (33-106): Function state mutability can be restricted to view
 // Warning 6328: (61-70): CHC: Assertion violation happens here.\nCounterexample:\ns = false\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
 // Warning 3993: The BMC engine of the SMTChecker is deprecated and will be removed in a future release. Please use the CHC engine instead.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
@@ -1,7 +1,7 @@
 abstract contract A {
 	bool s;
 
-	function f() public view mod {
+	function f() public mod {
 		assert(s); // holds for B
 		assert(!s); // fails for B
 	}
@@ -18,8 +18,9 @@ contract B is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 8429: (125-148): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 8429: (171-238): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 6328: (94-104): CHC: Assertion violation happens here.\nCounterexample:\ns = true\nx = true\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
+// Warning 8429: (120-143): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (166-233): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 2018: (33-118): Function state mutability can be restricted to view
+// Warning 6328: (89-99): CHC: Assertion violation happens here.\nCounterexample:\ns = true\nx = true\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 3993: The BMC engine of the SMTChecker is deprecated and will be removed in a future release. Please use the CHC engine instead.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
@@ -20,7 +20,6 @@ contract B is A {
 // ----
 // Warning 8429: (120-143): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 8429: (166-233): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 2018: (33-118): Function state mutability can be restricted to view
 // Warning 6328: (89-99): CHC: Assertion violation happens here.\nCounterexample:\ns = true\nx = true\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 3993: The BMC engine of the SMTChecker is deprecated and will be removed in a future release. Please use the CHC engine instead.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
@@ -1,7 +1,7 @@
 abstract contract A {
 	int x = 0;
 
-	function f() public view mod() {
+	function f() public mod() {
 		assert(x != 0); // does not hold for A, but A is abstract so it should not be reported
 		assert(x != 1); // fails for B
 		assert(x != 2); // fails for C
@@ -36,12 +36,13 @@ contract D is B,C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 8429: (262-294): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 8429: (317-367): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 8429: (390-440): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 8429: (465-520): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 6328: (160-174): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nB.constructor()\nState: x = 0\nA.f()
-// Warning 6328: (193-207): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nA.f()
-// Warning 6328: (226-240): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()\nState: x = 0\nA.f()
+// Warning 8429: (257-289): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (312-362): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (385-435): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (460-515): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 2018: (36-254): Function state mutability can be restricted to view
+// Warning 6328: (155-169): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nB.constructor()\nState: x = 0\nA.f()
+// Warning 6328: (188-202): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nA.f()
+// Warning 6328: (221-235): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()\nState: x = 0\nA.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 3993: The BMC engine of the SMTChecker is deprecated and will be removed in a future release. Please use the CHC engine instead.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
@@ -40,7 +40,6 @@ contract D is B,C {
 // Warning 8429: (312-362): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 8429: (385-435): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 8429: (460-515): Virtual modifiers are deprecated and scheduled for removal.
-// Warning 2018: (36-254): Function state mutability can be restricted to view
 // Warning 6328: (155-169): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nB.constructor()\nState: x = 0\nA.f()
 // Warning 6328: (188-202): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nA.f()
 // Warning 6328: (221-235): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()\nState: x = 0\nA.f()

--- a/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_skips_state_mutability_check.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_skips_state_mutability_check.sol
@@ -1,0 +1,25 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+
+
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+
+
+// Modifier m is inferred pure because super.f() in B statically binds to A.f.
+// The C3 linearization of D is [D, B, X, A], where it resolves to X.f instead.
+// m is not overridden anywhere and is not even virtual.
+contract B is A {
+    modifier m() { super.f(); _; }
+    function g() public pure m returns (uint256) { return 2; }
+}
+
+
+contract D is A, X, B {
+    function f() public pure override(A, X) returns (uint256) { return 7; }
+}
+// ----
+// TypeError 1614: (436-466): Modifier "m" has state mutability "nonpayable" in "D", but "B.g", which uses it, is declared "pure".

--- a/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_skips_state_mutability_check_view.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_skips_state_mutability_check_view.sol
@@ -1,0 +1,23 @@
+contract A {
+    function f() public view virtual returns (uint256) { return 1; }
+}
+
+
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+
+
+// As super_in_modifier_skips_state_mutability_check, but view.
+contract B is A {
+    modifier m() { super.f(); _; }
+    function g() public view m returns (uint256) { return 2; }
+}
+
+
+contract D is A, X, B {
+    function f() public view override(A, X) returns (uint256) { return s; }
+}
+// ----
+// TypeError 1614: (284-314): Modifier "m" has state mutability "nonpayable" in "D", but "B.g", which uses it, is declared "view".

--- a/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_state_mutability_ok.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/super_in_modifier_state_mutability_ok.sol
@@ -1,0 +1,22 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+
+
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+
+
+// super.f() in m resolves to X.f in D, but g is nonpayable, so it may.
+contract B is A {
+    modifier m() { super.f(); _; }
+    function g() public m returns (uint256) { return 2; }
+}
+
+
+contract D is A, X, B {
+    function f() public pure override(A, X) returns (uint256) { return 7; }
+}
+// ----

--- a/test/libsolidity/syntaxTests/inheritance/override/super_skips_state_mutability_check.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/super_skips_state_mutability_check.sol
@@ -1,0 +1,23 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+
+
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+
+
+contract B is A {
+    function f() public pure virtual override returns (uint256) { return super.f(); }
+}
+
+
+// C3 linearization of D is [D, B, X, A]. B.f is checked as pure against A.f,
+// but super.f() in B resolves to X.f, which writes storage.
+contract D is A, X, B {
+    function f() public pure override(A, X, B) returns (uint256) { return super.f(); }
+}
+// ----
+// TypeError 7898: (445-557): "B.f" is declared "pure", but in this contract its super call resolves to "X.f", which is "nonpayable".

--- a/test/libsolidity/syntaxTests/inheritance/override/super_skips_state_mutability_check_view.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/super_skips_state_mutability_check_view.sol
@@ -1,0 +1,22 @@
+contract A {
+    function f() public view virtual returns (uint256) { return 1; }
+}
+
+
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+
+
+contract B is A {
+    function f() public view virtual override returns (uint256) { return super.f(); }
+}
+
+
+// As super_skips_state_mutability_check, but view, which the EVM enforces.
+contract D is A, X, B {
+    function f() public view override(A, X, B) returns (uint256) { return super.f(); }
+}
+// ----
+// TypeError 7898: (382-494): "B.f" is declared "view", but in this contract its super call resolves to "X.f", which is "nonpayable".

--- a/test/libsolidity/syntaxTests/inheritance/override/virtual_modifier_skips_state_mutability_check.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/virtual_modifier_skips_state_mutability_check.sol
@@ -1,0 +1,15 @@
+contract A {
+    uint256 public s;
+    modifier m() virtual { _; }
+    function f() public pure m returns (uint256) { return 1; }
+}
+
+
+// A.f is checked as pure against A.m, but in D the modifier resolves to D.m,
+// which writes storage.
+contract D is A {
+    modifier m() override { s = 5; _; }
+}
+// ----
+// Warning 8429: (39-66): Virtual modifiers are deprecated and scheduled for removal.
+// TypeError 1614: (259-294): This modifier overrides "m" with state mutability "nonpayable", but "A.f", which uses it, is declared "pure".

--- a/test/libsolidity/syntaxTests/inheritance/override/virtual_modifier_skips_state_mutability_check.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/virtual_modifier_skips_state_mutability_check.sol
@@ -12,4 +12,4 @@ contract D is A {
 }
 // ----
 // Warning 8429: (39-66): Virtual modifiers are deprecated and scheduled for removal.
-// TypeError 1614: (259-294): This modifier overrides "m" with state mutability "nonpayable", but "A.f", which uses it, is declared "pure".
+// TypeError 1614: (259-294): Modifier "m" has state mutability "nonpayable" in "D", but "A.f", which uses it, is declared "pure".


### PR DESCRIPTION
A super call in a modifier body resolves over the most derived contract's
linearization, so the mutability of such a modifier belongs to the
(modifier, contract) pair rather than to the modifier alone. Key the
inference cache on both and track the contract while inferring.

Subsumes the modifier override case, which is the same comparison, so
error 1614 loses its override-specific wording.

## Stacked on

https://github.com/argotorg/solidity/pull/16932

## Fixes

#16931