### PR TITLE
Optimizer: Eliminate dead mstore instructions from memoryguard-derived struct allocations

### DIFF
--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -36,7 +36,8 @@ KnowledgeBase::KnowledgeBase(std::map<YulName, AssignedValue> const& _ssaValues,
 	m_valuesAreSSA(true),
 	m_variableValues([_ssaValues](YulName _var) { return util::valueOrNullptr(_ssaValues, _var); }),
 	m_addBuiltinHandle(_dialect.findBuiltin("add")),
-	m_subBuiltinHandle(_dialect.findBuiltin("sub"))
+	m_subBuiltinHandle(_dialect.findBuiltin("sub")),
+	m_memoryGuardBuiltinHandle(_dialect.findBuiltin("memoryguard"))
 {}
 
 bool KnowledgeBase::knownToBeDifferent(YulName _a, YulName _b)
@@ -138,6 +139,7 @@ std::optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression c
 				}
 		}
 		else if (std::get<BuiltinName>(f->functionName).handle == m_subBuiltinHandle)
+		{
 			if (std::optional<VariableOffset> a = explore(f->arguments[0]))
 				if (std::optional<VariableOffset> b = explore(f->arguments[1]))
 				{
@@ -148,6 +150,18 @@ std::optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression c
 						// b is constant
 						return VariableOffset{a->reference, offset};
 				}
+		}
+		else if (
+			m_memoryGuardBuiltinHandle &&
+			std::get<BuiltinName>(f->functionName).handle == m_memoryGuardBuiltinHandle
+		)
+		{
+			// memoryguard(N) compiles to the constant N.
+			// Its sole argument is always a literal (enforced by the builtin's literalArguments metadata).
+			yulAssert(f->arguments.size() == 1, "memoryguard takes exactly one argument");
+			if (Literal const* lit = std::get_if<Literal>(&f->arguments.front()))
+				return VariableOffset{YulName{}, lit->value.value()};
+		}
 	}
 
 	return std::nullopt;

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -66,7 +66,8 @@ public:
 	explicit KnowledgeBase(std::function<AssignedValue const*(YulName)> _variableValues, Dialect const& _dialect):
 		m_variableValues(std::move(_variableValues)),
 		m_addBuiltinHandle(_dialect.findBuiltin("add")),
-		m_subBuiltinHandle(_dialect.findBuiltin("sub"))
+		m_subBuiltinHandle(_dialect.findBuiltin("sub")),
+		m_memoryGuardBuiltinHandle(_dialect.findBuiltin("memoryguard"))
 	{}
 	/// Constructor to use if source code is in SSA form and values are constant.
 	explicit KnowledgeBase(std::map<YulName, AssignedValue> const& _ssaValues, Dialect const& _dialect);
@@ -120,6 +121,7 @@ private:
 	std::function<AssignedValue const*(YulName)> m_variableValues;
 	std::optional<BuiltinHandle> m_addBuiltinHandle;
 	std::optional<BuiltinHandle> m_subBuiltinHandle;
+	std::optional<BuiltinHandle> m_memoryGuardBuiltinHandle;
 
 	/// Offsets for each variable to one representative per group.
 	/// The empty string is the representative of the constant value zero.

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/memoryguard_dead_store.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/memoryguard_dead_store.yul
@@ -1,0 +1,57 @@
+// Regression test for: dead mstore instructions not eliminated when the store base
+// is derived from memoryguard(N).
+//
+// The KnowledgeBase must recognize memoryguard(literal) as a constant so that
+// knownUnrelated() can prove that stores at _1..._1+96 do not overlap with
+// a read at a different constant address.
+//
+// This simulates the pattern after LoadResolver has already forwarded the mload(0x40)
+// result so that memPos is a known constant (newFreePtr), enabling the
+// unusedStoreEliminator to prove non-overlap and remove the dead stores.
+{
+    let _1 := memoryguard(0x80)
+    let newFreePtr := add(_1, 128)
+    mstore(64, newFreePtr)
+
+    let _a1 := _1
+    let _a2 := add(_1, 32)
+    let _a3 := add(_1, 64)
+    let _a4 := add(_1, 96)
+
+    let value := calldataload(36)
+    let v2 := calldataload(68)
+    let v3 := calldataload(100)
+    let v4 := calldataload(132)
+
+    mstore(_a1, value)    // dead: _a1=0x80, newFreePtr=0x100, non-overlapping
+    mstore(_a2, v2)       // dead: _a2=0xa0
+    mstore(_a3, v3)       // dead: _a3=0xc0
+    mstore(_a4, v4)       // dead: _a4=0xe0
+
+    // Use newFreePtr (=0x100) as the write/return target,
+    // known to be >=32 bytes away from _a1..._a4 (=0x80..0xfe).
+    mstore(newFreePtr, value)
+    return(newFreePtr, 32)
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let _1 := memoryguard(0x80)
+//         let newFreePtr := add(_1, 128)
+//         let _3 := 64
+//         let _a1 := _1
+//         let _a2 := add(_1, 32)
+//         let _a3 := add(_1, 64)
+//         let _a4 := add(_1, 96)
+//         let value := calldataload(36)
+//         let v2 := calldataload(68)
+//         let v3 := calldataload(100)
+//         let v4 := calldataload(132)
+//         mstore(newFreePtr, value)
+//         return(newFreePtr, 32)
+//     }
+// }


### PR DESCRIPTION
## Description

Fixes #16927

Fixes a missed optimisation in the IR pipeline where accessing a single member of an `abi.decode`-d struct leaves several dead `mstore` instructions that the `UnusedStoreEliminator` should remove.

**Reproducer:**
```solidity
struct OnlyUnvalidated { uint256 tokenId; uint256 b; uint256 c; uint256 d; }

contract C {
    function decodeUnvalidatedStruct(bytes calldata data) external pure returns (uint256) {
        return abi.decode(data, (OnlyUnvalidated)).tokenId;
    }
}
```

The IR optimizer generates a scratch region at `_1 = memoryguard(0x80)`, writes all four struct members into it, and then — because `LoadResolver` already forwards the `.tokenId` value directly — the four `mstore`s are dead. However, `UnusedStoreEliminator` was unable to remove them because `KnowledgeBase::explore()` did not recognise `memoryguard(N)` as the constant `N`. Without that knowledge, no non-overlap between the scratch slots (`0x80`–`0xfe`) and the return target (`newFreePtr = 0x100`) could be proved, so all four stores were conservatively kept.

**Fix:**

Teach `KnowledgeBase::explore(Expression const&)` to fold `memoryguard(literal)` to its argument value, exactly like a plain `Literal` node. `memoryguard` always takes a single literal operand (enforced by the builtin's `literalArguments` metadata), so this is always safe.

Changes:
- **`libyul/optimiser/KnowledgeBase.h`** — add `std::optional<BuiltinHandle> m_memoryGuardBuiltinHandle` and initialise it in both constructors (same pattern as `m_addBuiltinHandle` / `m_subBuiltinHandle`).
- **`libyul/optimiser/KnowledgeBase.cpp`** — add a new `else if` branch in `explore(Expression const&)` that returns `VariableOffset{YulName{}, literal->value.value()}` when the callee is `memoryguard`. Also adds the missing braces around the `sub` branch to keep the `else if` chain well-formed.
- **`test/libyul/yulOptimizerTests/unusedStoreEliminator/memoryguard_dead_store.yul`** — new regression test directly modelling the IR pattern from the bug report; asserts that all four dead stores are eliminated.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

- [ ] No AI tools were used

[Antigravity](https://antigravity.dev) (Claude Sonnet 4.6) was used to navigate the codebase, cross-reference the interaction between `KnowledgeBase`, `UnusedStoreEliminator`, and `UnusedStoreBase`, and to draft this PR description. All code changes were authored, reviewed, and tested by the contributor.