### PR TITLE
fix: check state mutability of super calls against derived linearizations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 * Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
+* View Pure Checker: Report an error when a `super` call inside a `pure` or `view` function resolves to a more state-modifying function in the linearization of an inheriting contract.
 
 Build System:
 * Update minimum version requirement of Boost to 1.83.0 for Windows build. This matches the minimum version for other systems.

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -25,6 +25,7 @@
 #include <libevmasm/SemanticInformation.h>
 
 #include <functional>
+#include <set>
 #include <utility>
 #include <variant>
 
@@ -131,12 +132,20 @@ bool ViewPureChecker::check()
 	for (auto const& source: m_ast)
 		source->accept(*this);
 
+	checkSuperCallDispatch();
+
 	return !m_errors;
 }
 
 bool ViewPureChecker::visit(ImportDirective const&)
 {
 	return false;
+}
+
+bool ViewPureChecker::visit(ContractDefinition const& _contract)
+{
+	m_contracts.push_back(&_contract);
+	return true;
 }
 
 bool ViewPureChecker::visit(FunctionDefinition const& _funDef)
@@ -352,6 +361,77 @@ void ViewPureChecker::endVisit(FunctionCall const& _functionCall)
 		dynamic_cast<FunctionType const&>(*_functionCall.expression().annotation().type).stateMutability(),
 		_functionCall.location()
 	);
+
+	// The mutability reported above is the one of the function this call lexically resolves to.
+	// For `super` calls that is not necessarily the function that is actually going to be
+	// executed, so remember the call and re-check it in @a checkSuperCallDispatch.
+	auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression());
+	if (!m_currentFunction || !memberAccess)
+		return;
+
+	auto const* lexicallyResolvedFunction = dynamic_cast<FunctionDefinition const*>(
+		memberAccess->annotation().referencedDeclaration
+	);
+	if (!lexicallyResolvedFunction || *memberAccess->annotation().requiredLookup != VirtualLookup::Super)
+		return;
+
+	auto const* typeType = dynamic_cast<TypeType const*>(memberAccess->expression().annotation().type);
+	solAssert(typeType);
+	auto const* contractType = dynamic_cast<ContractType const*>(typeType->actualType());
+	solAssert(contractType && contractType->isSuper());
+
+	m_superCalls[&contractType->contractDefinition()].emplace_back(
+		SuperCall{&_functionCall, m_currentFunction, lexicallyResolvedFunction}
+	);
+}
+
+void ViewPureChecker::checkSuperCallDispatch()
+{
+	std::set<std::pair<FunctionCall const*, FunctionDefinition const*>> reportedCalls;
+
+	for (ContractDefinition const* contract: m_contracts)
+		for (ContractDefinition const* base: contract->annotation().linearizedBaseContracts)
+		{
+			auto const superCalls = m_superCalls.find(base);
+			if (superCalls == m_superCalls.end())
+				continue;
+
+			for (SuperCall const& superCall: superCalls->second)
+			{
+				FunctionDefinition const* resolvedFunction = ASTNode::resolveFunctionCall(*superCall.call, contract);
+				solAssert(resolvedFunction);
+
+				// The lexically resolved function has already been checked by the main pass.
+				if (resolvedFunction == superCall.lexicallyResolvedFunction)
+					continue;
+
+				StateMutability mutability = resolvedFunction->stateMutability();
+				// We only require "nonpayable" to call a payable function.
+				if (mutability == StateMutability::Payable)
+					mutability = StateMutability::NonPayable;
+
+				if (mutability <= superCall.enclosingFunction->stateMutability())
+					continue;
+
+				// The same call can be reached through several derived contracts. Report it only once.
+				if (!reportedCalls.insert({superCall.call, resolvedFunction}).second)
+					continue;
+
+				m_errorReporter.typeError(
+					7557_error,
+					superCall.call->location(),
+					SecondarySourceLocation{}
+						.append("This is the linearization that makes the call resolve to it.", contract->location())
+						.append("The function it resolves to is defined here.", resolvedFunction->location()),
+					"Function cannot be declared as " +
+					stateMutabilityToString(superCall.enclosingFunction->stateMutability()) +
+					" because this \"super\" call resolves to a function that (potentially) " +
+					(mutability == StateMutability::NonPayable ? "modifies the state" : "reads from the environment or state") +
+					" in the linearization of a contract inheriting from this one."
+				);
+				m_errors = true;
+			}
+		}
 }
 
 bool ViewPureChecker::visit(MemberAccess const& _memberAccess)

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -50,8 +50,18 @@ private:
 		langutil::SourceLocation location;
 	};
 
+	/// A call of the form ``super.f()``, together with the function whose body contains it
+	/// and the function it resolves to in the linearization of the contract it is defined in.
+	struct SuperCall
+	{
+		FunctionCall const* call;
+		FunctionDefinition const* enclosingFunction;
+		FunctionDefinition const* lexicallyResolvedFunction;
+	};
+
 	bool visit(ImportDirective const&) override;
 
+	bool visit(ContractDefinition const& _contract) override;
 	bool visit(FunctionDefinition const& _funDef) override;
 	void endVisit(FunctionDefinition const& _funDef) override;
 	void endVisit(BinaryOperation const& _binaryOperation) override;
@@ -80,6 +90,12 @@ private:
 	/// Determines the mutability of modifier if not already cached.
 	MutabilityAndLocation const& modifierMutability(ModifierDefinition const& _modifier);
 
+	/// ``super`` calls are type-checked against the linearization of the contract they are
+	/// defined in, but resolved against the linearization of the most derived contract.
+	/// Re-checks every collected ``super`` call against the linearization of each contract
+	/// inheriting from the one that contains it.
+	void checkSuperCallDispatch();
+
 	std::vector<std::shared_ptr<ASTNode>> const& m_ast;
 	langutil::ErrorReporter& m_errorReporter;
 
@@ -87,6 +103,8 @@ private:
 	MutabilityAndLocation m_bestMutabilityAndLocation = MutabilityAndLocation{StateMutability::Payable, langutil::SourceLocation()};
 	FunctionDefinition const* m_currentFunction = nullptr;
 	std::map<ModifierDefinition const*, MutabilityAndLocation> m_inferredMutability;
+	std::vector<ContractDefinition const*> m_contracts;
+	std::map<ContractDefinition const*, std::vector<SuperCall>> m_superCalls;
 };
 
 }

--- a/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_compatible.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_compatible.sol
@@ -1,0 +1,13 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+contract X is A {
+    function f() public pure virtual override returns (uint256) { return 2; }
+}
+contract B is A {
+    function f() public pure virtual override returns (uint256) { return super.f(); }
+}
+contract D is A, X, B {
+    function f() public pure override(A, X, B) returns (uint256) { return super.f(); }
+}
+// ----

--- a/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_to_state_modifying.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_to_state_modifying.sol
@@ -1,0 +1,15 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+contract X {
+    uint256 public s;
+    function f() public virtual returns (uint256) { s = 5; return 100; }
+}
+contract B is A {
+    function f() public pure virtual override returns (uint256) { return super.f(); }
+}
+contract D is A, X, B {
+    function f() public pure override(A, X, B) returns (uint256) { return super.f(); }
+}
+// ----
+// TypeError 7557: (285-294): Function cannot be declared as pure because this "super" call resolves to a function that (potentially) modifies the state in the linearization of a contract inheriting from this one.

--- a/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_to_view.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/super_dispatch_to_view.sol
@@ -1,0 +1,15 @@
+contract A {
+    function f() public pure virtual returns (uint256) { return 1; }
+}
+contract X {
+    uint256 public s;
+    function f() public view virtual returns (uint256) { return s; }
+}
+contract B is A {
+    function f() public pure virtual override returns (uint256) { return super.f(); }
+}
+contract D is A, X, B {
+    function f() public pure override(A, X, B) returns (uint256) { return super.f(); }
+}
+// ----
+// TypeError 7557: (281-290): Function cannot be declared as pure because this "super" call resolves to a function that (potentially) reads from the environment or state in the linearization of a contract inheriting from this one.


### PR DESCRIPTION
Fixes #16930.

`super.f()` is bound to a declaration at type-check time against the linearization of the contract that lexically contains it, then re-resolved at code generation against the linearization of the most derived contract. State mutability is only checked at the first step.

`ViewPureChecker` reads mutability from the lexically bound target (`ViewPureChecker.cpp:346`), while the real resolution happens in `FunctionDefinition::resolveVirtual` (`AST.cpp:564`), which matches on parameter types and does not compare mutability. `OverrideChecker`'s error 6959 is what makes ordinary virtual dispatch safe, but it never fires here, because the spliced-in function is not an override of anything the lexical target overrides.

There are three places virtual re-resolution happens and they are guarded differently:

| dispatch | re-resolution | guarded |
|---|---|---|
| plain virtual call | `resolveVirtual` with no search start | yes, `OverrideChecker` 6959 |
| `super` call | `resolveVirtual` with a search start | no |
| modifier | `ModifierDefinition::resolveVirtual` | no, and modifiers carry no `stateMutability` to compare |

This PR closes the second row. The third is #16931.

## It is reachable at runtime, not only in the analysis

The `pure` function really does write storage. A semantic test on the unpatched compiler, run against evmone:

```
// s() -> 0
// f() -> 100
// s() -> 5
```

That test is deliberately not included in this PR, because with the fix applied the contract is correctly rejected and the test could not compile. It is evidence for this description, not a regression test.

## Affected versions

Compiled the reproducer with released compilers. 0.6.0, 0.6.7 and 0.6.12 all reject it with `Overriding function changes state mutability from "nonpayable" to "pure"`. 0.7.0, 0.8.0 and 0.8.36 all accept it. So this was introduced in **0.7.0**, when the exact-match rule on overridden mutability was relaxed to allow stricter overrides.

That looks like it qualifies for a `docs/bugs.json` entry. I have not added one, because `uid`, `fixed` and the `link` to a blog post are yours to assign. Happy to add it in this PR if you tell me the values, or to leave it to you.

## One thing the issue does not mention

The entry point does not have to use `super` at all. A `pure` function in `D` calling `B.f()` explicitly reaches the same chain, so checking only the super chain from the entry point is not sufficient. This is why the check is written the way it is.

## The change

The check records every `super` call site keyed by its lexical contract, then after the main pass re-resolves each site against the linearization of every contract inheriting from that one, using the existing `ASTNode::resolveFunctionCall`. It reports when the re-resolved target is more state-modifying than the function containing the call. Sites that re-resolve to the lexical target are skipped so the main pass keeps ownership and no duplicate errors appear.

Three syntax tests under `test/libsolidity/syntaxTests/viewPureChecker/`, including a negative control that must stay clean.

## Checks

```
soltest --vm libevmone.dylib          8203 test cases, no errors detected
isoltest --vm libevmone.dylib         full run, semantic and SMT enabled
scripts/error_codes.py --check        No incorrect IDs found
scripts/check_style.sh                clean
```

I also ran every file in `test/libsolidity/semanticTests` through the patched compiler and no existing file newly triggers the error.

One `isoltest` case does fail here, `smtCheckerTests/operators/slice_default_start.sol`, and it is not from this change. Running that file through `solc --model-checker-engine all` gives identical output with and without the patch: `4 verification condition(s) proved safe` and an extra BMC warning, where the expectation records `5` and no BMC line. I am on z3 5.1.0 from Homebrew rather than the version CI pins, which is the likely cause.

I did not run clang-format, because 19 of the 20 existing files in `libsolidity/analysis/` do not match it either, so it does not appear to be the gate here.

## Three things that are my judgement

The check is conservative. It reports whenever any inheriting contract's linearization produces a looser target, without proving that path is reachable. Code that compiles today and is provably safe would now be rejected. The explicit `B.f()` variant above is why I did not try to establish reachability, but a stricter analysis is possible if you want one.

The issue asks for the error on the joining contract. I report at the `super` call site with the joining contract as a secondary location, because that is where the author can act. Easy to flip.

Error `7557` was picked by scanning for a free ID. Tell me if there is an allocation convention.

## Known gap, stated rather than left to be found

`super` calls inside modifier bodies are not covered by this PR. The call site is not dropped: a modifier body is walked with `m_currentFunction == nullptr`, but `reportMutability` still updates the aggregate before the null check, that aggregate is cached at `endVisit(ModifierDefinition)`, and `endVisit(ModifierInvocation)` replays it against each using function. The problem is that the replayed mutability is the statically typed one.

Closing it means keying the mutability cache on `(modifier, mostDerivedContract)` rather than on the modifier alone, so that re-walking a modifier body resolves `super` against that contract. That builds directly on the per-contract pass in #16931, which is why I left it rather than half-solving it here.
