### PR TITLE
Evaluation of reason expression of `revert` and `require` expression when `--revert-strings strip` is used.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.
+* Code Generator: Fix evaluation of reason expression for `require` and `revert` functions in legacy pipeline when `--revert-strings strip` is set.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 * Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
 * Yul Optimizer: Fix incorrect removal of `returndatacopy()` operations referencing a stale result of `returndatasize()`.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -886,11 +886,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				solAssert(function.parameterTypes().size() == 1, "");
 				if (m_context.revertStrings() == RevertStrings::Strip)
 				{
-					if (!*arguments.front()->annotation().isPure)
-					{
-						arguments.front()->accept(*this);
-						utils().popStackElement(*arguments.front()->annotation().type);
-					}
+					arguments.front()->accept(*this);
+					utils().popStackElement(*arguments.front()->annotation().type);
 					m_context.appendRevert();
 				}
 				else
@@ -1361,11 +1358,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 
 				if (m_context.revertStrings() == RevertStrings::Strip)
 				{
-					if (!*arguments.at(1)->annotation().isPure)
-					{
-						arguments.at(1)->accept(*this);
-						utils().popStackElement(*arguments.at(1)->annotation().type);
-					}
+					arguments.at(1)->accept(*this);
+					utils().popStackElement(*arguments.at(1)->annotation().type);
 				}
 				else
 				{

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -300,6 +300,42 @@ bool ExpressionCompiler::visit(Conditional const& _condition)
 	return false;
 }
 
+void ExpressionCompiler::evaluateForSideEffectsAndDiscard(Expression const& _expression)
+{
+	Expression const& expression = *resolveOuterUnaryTuples(&_expression);
+
+	if (auto const* conditional = dynamic_cast<Conditional const*>(&expression))
+	{
+		// The condition, and whichever one of the two branches ends up being selected at runtime,
+		// are both evaluated (recursively, so either can still panic on its own) purely for their
+		// side effects. The branch that is not taken is skipped entirely and its value never needs
+		// to be materialized.
+		CompilerContext::LocationSetter locationSetter(m_context, *conditional);
+		conditional->condition().accept(*this);
+		evmasm::AssemblyItem trueTag = m_context.appendConditionalJump();
+		evaluateForSideEffectsAndDiscard(conditional->falseExpression());
+		evmasm::AssemblyItem endTag = m_context.appendJumpToNew();
+		m_context << trueTag;
+		evaluateForSideEffectsAndDiscard(conditional->trueExpression());
+		m_context << endTag;
+		return;
+	}
+
+	if (auto const* identifier = dynamic_cast<Identifier const*>(&expression))
+		if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			if (variable->isConstant())
+			{
+				// Referencing a constant normally materializes its value converted to the constant's
+				// declared type (e.g. encodes a string constant into memory). Evaluate the initializer
+				// itself instead, since the converted/materialized value is never used here.
+				evaluateForSideEffectsAndDiscard(*variable->value());
+				return;
+			}
+
+	expression.accept(*this);
+	utils().popStackElement(*expression.annotation().type);
+}
+
 bool ExpressionCompiler::visit(Assignment const& _assignment)
 {
 	CompilerContext::LocationSetter locationSetter(m_context, _assignment);
@@ -886,8 +922,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				solAssert(function.parameterTypes().size() == 1, "");
 				if (m_context.revertStrings() == RevertStrings::Strip)
 				{
-					arguments.front()->accept(*this);
-					utils().popStackElement(*arguments.front()->annotation().type);
+					evaluateForSideEffectsAndDiscard(*arguments.front());
 					m_context.appendRevert();
 				}
 				else
@@ -1357,10 +1392,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				}
 
 				if (m_context.revertStrings() == RevertStrings::Strip)
-				{
-					arguments.at(1)->accept(*this);
-					utils().popStackElement(*arguments.at(1)->annotation().type);
-				}
+					evaluateForSideEffectsAndDiscard(*arguments.at(1));
 				else
 				{
 					arguments.at(1)->accept(*this);

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -136,6 +136,10 @@ private:
 
 	void acceptAndConvert(Expression const& _expression, Type const& _type, bool _cleanupNeeded = false);
 
+	/// Evaluates @a _expression for its side effects (e.g. panics) and discards the result, avoiding
+	/// unnecessary materialization (e.g. string/bytes memory encoding) of values that are never used.
+	void evaluateForSideEffectsAndDiscard(Expression const& _expression);
+
 	/// @returns the CompilerUtils object containing the current context.
 	CompilerUtils utils();
 

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -22,12 +22,65 @@
 #include <test/Metadata.h>
 #include <test/Common.h>
 
+#include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
+
 #include <boost/test/unit_test.hpp>
+
+#include <regex>
 
 using namespace solidity::test;
 
 namespace solidity::frontend::test
 {
+
+namespace
+{
+
+/// Returns true if @a _reason appears anywhere in @a _assembly: as contiguous ASCII bytes, as a
+/// standalone hex constant that decodes to it directly (e.g. legacy codegen's
+/// `0x7265766572745f61...` for "revert_a", zero-padded), or as a bit-packed `shl(shift, value)`
+/// constant - a Yul optimizer representation for a mostly-zero 256-bit word that a plain
+/// substring search would miss entirely.
+bool assemblyContainsString(std::string const& _assembly, std::string const& _reason)
+{
+	if (_assembly.find(_reason) != std::string::npos)
+		return true;
+
+	static std::regex const hexPattern(R"(0x([0-9a-fA-F]+))");
+	for (
+		auto it = std::sregex_iterator(_assembly.begin(), _assembly.end(), hexPattern);
+		it != std::sregex_iterator();
+		++it
+	)
+	{
+		std::string hex = (*it)[1].str();
+		if (hex.size() % 2 != 0)
+			hex = "0" + hex;
+		bytes const decodedBytes = util::fromHex(hex);
+		std::string const decoded(decodedBytes.begin(), decodedBytes.end());
+		if (decoded.find(_reason) != std::string::npos)
+			return true;
+	}
+
+	static std::regex const shlPattern(R"(shl\(0x([0-9a-fA-F]+),\s*0x([0-9a-fA-F]+)\))");
+	for (
+		auto it = std::sregex_iterator(_assembly.begin(), _assembly.end(), shlPattern);
+		it != std::sregex_iterator();
+		++it
+	)
+	{
+		unsigned shift = static_cast<unsigned>(std::stoul((*it)[1].str(), nullptr, 16));
+		u256 value(std::string("0x") + (*it)[2].str());
+		bytes packed = toBigEndian(value << shift);
+		std::string const packedString(packed.begin(), packed.end());
+		if (packedString.find(_reason) != std::string::npos)
+			return true;
+	}
+	return false;
+}
+
+}
 
 class SolidityCompilerFixture: protected AnalysisFramework
 {
@@ -67,6 +120,123 @@ BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 	unsigned threshold = evmVersion.hasPush0() ? 9 : 10;
 	BOOST_CHECK(runtimeBytecode.size() >= threshold);
 	BOOST_CHECK(runtimeBytecode.size() <= 30);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+class RevertStringsStripFixture: protected AnalysisFramework
+{
+	void setupCompiler(CompilerStack& _compiler) override
+	{
+		AnalysisFramework::setupCompiler(_compiler);
+		_compiler.setRevertStringBehaviour(RevertStrings::Strip);
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(RevertStringsStrip, RevertStringsStripFixture)
+
+BOOST_AUTO_TEST_CASE(reason_expression_evaluation_does_not_leak_string_data)
+{
+	// Reason expressions below still have to be evaluated (they may panic), but since the encoded
+	// string value is discarded by --revert-strings strip, none of the literal text should ever end
+	// up materialized in memory, and therefore should never appear in the bytecode either.
+	char const* sourceCode = R"(
+		contract C {
+			string constant CONSTANT_REASON = (new bytes(0))[0] == bytes1(0) ? "constant_a" : "constant_b";
+
+			function requireReasonConditionalIsEvaluated() external pure {
+				require(true, (new bytes(0))[0] == bytes1(0) ? "require_a" : "require_b");
+			}
+
+			function revertReasonConditionalIsEvaluated() external pure {
+				revert(type(uint8).max + 1 == 0 ? "revert_a" : "revert_b");
+			}
+
+			function revertReasonConstantIsEvaluated() external pure {
+				revert(CONSTANT_REASON);
+			}
+
+			function revertReasonNestedConditionalIsEvaluated() external pure {
+				revert(true ? (1 / type(uint8).min == 0 ? "nested_a" : "nested_b") : "nested_c");
+			}
+		}
+	)";
+
+	BOOST_REQUIRE(runFramework(sourceCode, PipelineStage::Compilation));
+	BOOST_REQUIRE_MESSAGE(
+		pipelineSuccessful(),
+		"Contract compilation failed:\n" + formatErrors(filteredErrors(), true /* _colored */)
+	);
+
+	std::string const assembly = compiler().assemblyString("C", {});
+
+	for (std::string const reason: {"require_a", "require_b", "revert_a", "revert_b", "constant_a", "constant_b", "nested_a", "nested_b", "nested_c"})
+		BOOST_CHECK_MESSAGE(
+			!assemblyContainsString(assembly, reason),
+			"Revert reason string \"" + reason + "\" leaked into the bytecode despite --revert-strings strip."
+		);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+class ViaIRRevertStringsStripFixture: protected AnalysisFramework
+{
+	void setupCompiler(CompilerStack& _compiler) override
+	{
+		AnalysisFramework::setupCompiler(_compiler);
+		_compiler.setViaIR(true);
+		_compiler.setOptimiserSettings(true);
+		_compiler.setRevertStringBehaviour(RevertStrings::Strip);
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(ViaIRRevertStringsStrip, ViaIRRevertStringsStripFixture)
+
+BOOST_AUTO_TEST_CASE(reason_expression_evaluation_does_not_leak_string_data)
+{
+	// Same intent as RevertStringsStrip/reason_expression_evaluation_does_not_leak_string_data, but
+	// compiled via-ir with the optimizer on. Deliberately avoids an array bounds check (e.g.
+	// `(new bytes(0))[0]`) as a require() reason's condition: unlike revert(reason), or require()
+	// reasons whose condition is a simple arithmetic check (as used here), a require() reason whose
+	// condition involves an array bounds check is NOT fully eliminated by the via-ir + --optimize
+	// pipeline (tracked separately, independent of this fix - see branch
+	// via-ir-require-reason-not-stripped).
+	char const* sourceCode = R"(
+		contract C {
+			enum MyEnum { A, B }
+			string constant CONSTANT_REASON = MyEnum(type(uint8).max) == MyEnum.A ? "constant_a" : "constant_b";
+
+			function requireReasonConditionalIsEvaluated() external pure {
+				require(true, type(uint8).max + 1 == 0 ? "require_a" : "require_b");
+			}
+
+			function revertReasonConditionalIsEvaluated() external pure {
+				revert(1 / type(uint8).min == 0 ? "revert_a" : "revert_b");
+			}
+
+			function revertReasonConstantIsEvaluated() external pure {
+				revert(CONSTANT_REASON);
+			}
+
+			function revertReasonNestedConditionalIsEvaluated() external pure {
+				revert(true ? (type(uint8).max + 1 == 0 ? "nested_a" : "nested_b") : "nested_c");
+			}
+		}
+	)";
+
+	BOOST_REQUIRE(runFramework(sourceCode, PipelineStage::Compilation));
+	BOOST_REQUIRE_MESSAGE(
+		pipelineSuccessful(),
+		"Contract compilation failed:\n" + formatErrors(filteredErrors(), true /* _colored */)
+	);
+
+	std::string const assembly = compiler().assemblyString("C", {});
+
+	for (std::string const reason: {"require_a", "require_b", "revert_a", "revert_b", "constant_a", "constant_b", "nested_a", "nested_b", "nested_c"})
+		BOOST_CHECK_MESSAGE(
+			!assemblyContainsString(assembly, reason),
+			"Revert reason string \"" + reason + "\" leaked into the via-ir bytecode despite --revert-strings strip."
+		);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/semanticTests/revertStrings/reason_expression_evaluation_with_stripped_revert_strings.sol
+++ b/test/libsolidity/semanticTests/revertStrings/reason_expression_evaluation_with_stripped_revert_strings.sol
@@ -1,0 +1,139 @@
+contract StripReasonPanic {
+    enum MyEnum { A, B }
+    string constant ARRAY_OUT_OF_BOUNDS_REASON = (new bytes(0))[0] == bytes1(0) ? "first" : "second";
+    string constant OVERFLOW_REASON = type(uint8).max + 1 == 0 ? "first" : "second";
+    string constant DIVISION_BY_ZERO_REASON = 1 / type(uint8).min == 0 ? "first" : "second";
+    string constant ENUM_CONVERSION_REASON = MyEnum(type(uint8).max) == MyEnum.A ? "first" : "second";
+
+    function requireReasonArrayOutOfBoundsIsEvaluated() external returns (uint256) {
+        require(true, (new bytes(0))[0] == bytes1(0) ? "first" : "second");
+        return 1;
+    }
+
+    function revertReasonArrayOutOfBoundsIsEvaluated() external returns (uint256) {
+        revert((new bytes(0))[0] == bytes1(0) ? "first" : "second");
+    }
+
+    function requireReasonOverflowIsEvaluated() external returns (uint256) {
+        require(true, type(uint8).max + 1 == 0 ? "first" : "second");
+        return 1;
+    }
+
+    function revertReasonOverflowIsEvaluated() external returns (uint256) {
+        revert(type(uint8).max + 1 == 0 ? "first" : "second");
+    }
+
+    function requireReasonDivisionByZeroIsEvaluated() external returns (uint256) {
+        require(true, 1 / type(uint8).min == 0 ? "first" : "second");
+        return 1;
+    }
+
+    function revertReasonDivisionByZeroIsEvaluated() external returns (uint256) {
+        revert(1 / type(uint8).min == 0 ? "first" : "second");
+    }
+
+    function requireReasonEnumConversionIsEvaluated() external returns (uint256) {
+        require(true, MyEnum(type(uint8).max) == MyEnum.A ? "first" : "second");
+        return 1;
+    }
+
+    function revertReasonEnumConversionIsEvaluated() external returns (uint256) {
+        revert(MyEnum(type(uint8).max) == MyEnum.A ? "first" : "second");
+    }
+
+    function requireReasonConstantIsEvaluated() external returns (uint256) {
+        require(true, ARRAY_OUT_OF_BOUNDS_REASON);
+        return 1;
+    }
+
+    function revertReasonConstantIsEvaluated() external returns (uint256) {
+        revert(ARRAY_OUT_OF_BOUNDS_REASON);
+    }
+
+    function requireReasonOverflowConstantIsEvaluated() external returns (uint256) {
+        require(true, OVERFLOW_REASON);
+        return 1;
+    }
+
+    function revertReasonOverflowConstantIsEvaluated() external returns (uint256) {
+        revert(OVERFLOW_REASON);
+    }
+
+    function requireReasonDivisionByZeroConstantIsEvaluated() external returns (uint256) {
+        require(true, DIVISION_BY_ZERO_REASON);
+        return 1;
+    }
+
+    function revertReasonDivisionByZeroConstantIsEvaluated() external returns (uint256) {
+        revert(DIVISION_BY_ZERO_REASON);
+    }
+
+    function requireReasonEnumConversionConstantIsEvaluated() external returns (uint256) {
+        require(true, ENUM_CONVERSION_REASON);
+        return 1;
+    }
+
+    function revertReasonEnumConversionConstantIsEvaluated() external returns (uint256) {
+        revert(ENUM_CONVERSION_REASON);
+    }
+
+    function requireReasonNestedConditionalTrueBranchIsEvaluated() external returns (uint256) {
+        require(
+            true,
+            true
+                ? (type(uint8).max + 1 == 0 ? "first" : "second")
+                : (1 / type(uint8).min == 0 ? "third" : "fourth")
+        );
+        return 1;
+    }
+
+    function revertReasonNestedConditionalTrueBranchIsEvaluated() external returns (uint256) {
+        revert(
+            true
+                ? (type(uint8).max + 1 == 0 ? "first" : "second")
+                : (1 / type(uint8).min == 0 ? "third" : "fourth")
+        );
+    }
+
+    function requireReasonNestedConditionalFalseBranchIsEvaluated() external returns (uint256) {
+        require(
+            true,
+            false
+                ? (type(uint8).max + 1 == 0 ? "first" : "second")
+                : (1 / type(uint8).min == 0 ? "third" : "fourth")
+        );
+        return 1;
+    }
+
+    function revertReasonNestedConditionalFalseBranchIsEvaluated() external returns (uint256) {
+        revert(
+            false
+                ? (type(uint8).max + 1 == 0 ? "first" : "second")
+                : (1 / type(uint8).min == 0 ? "third" : "fourth")
+        );
+    }
+}
+// ====
+// EVMVersion: >=byzantium
+// revertStrings: strip
+// ----
+// requireReasonArrayOutOfBoundsIsEvaluated() -> FAILURE, hex"4e487b71", 0x32
+// revertReasonArrayOutOfBoundsIsEvaluated() -> FAILURE, hex"4e487b71", 0x32
+// requireReasonOverflowIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// revertReasonOverflowIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// requireReasonDivisionByZeroIsEvaluated() -> FAILURE, hex"4e487b71", 0x12
+// revertReasonDivisionByZeroIsEvaluated() -> FAILURE, hex"4e487b71", 0x12
+// requireReasonEnumConversionIsEvaluated() -> FAILURE, hex"4e487b71", 0x21
+// revertReasonEnumConversionIsEvaluated() -> FAILURE, hex"4e487b71", 0x21
+// requireReasonConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x32
+// revertReasonConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x32
+// requireReasonOverflowConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// revertReasonOverflowConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// requireReasonDivisionByZeroConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x12
+// revertReasonDivisionByZeroConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x12
+// requireReasonEnumConversionConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x21
+// revertReasonEnumConversionConstantIsEvaluated() -> FAILURE, hex"4e487b71", 0x21
+// requireReasonNestedConditionalTrueBranchIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// revertReasonNestedConditionalTrueBranchIsEvaluated() -> FAILURE, hex"4e487b71", 0x11
+// requireReasonNestedConditionalFalseBranchIsEvaluated() -> FAILURE, hex"4e487b71", 0x12
+// revertReasonNestedConditionalFalseBranchIsEvaluated() -> FAILURE, hex"4e487b71", 0x12


### PR DESCRIPTION
## Description

This PR fixes inconsistency between legacy and via-ir pipeline regarding evaluation of the reason expression for `require` and `revert` expression in case of `--revert-strings strip` usage.

When `--revert-strings strip` flag is passed and in the legacy pipeline, evaluation of the reason expression in `require`/`revert` functions is omitted when the `isPure` flag for the expression is `true` (mean it’s a runtime constant). It can be `true` also for expressions which can panic. Not sure it was a reason to introduce this additional optimisation (to not evaluate the expression), but in via-ir it’s evaluated and popped from the stack. Legacy pipeline now copies this behaviour. 

## AI Disclosure

- [x] No AI tools were used
