### PR TITLE
CI: Give external test jobs a private npm cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1653,6 +1653,10 @@ jobs:
     environment:
       TERM: xterm
       COMPILE_ONLY: << parameters.compile_only >>
+      # Use a cache dir private to the job instead of the one baked into the image and also written
+      # to by the global pnpm install below (as root). Leftovers in its _cacache/tmp make npm fail
+      # with a random EEXIST, because cacache picks tmp file names from only 4 random bytes.
+      npm_config_cache: /tmp/npm-cache
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
The `t_ext` jobs run `npm install` against `~/.npm`, which is pre-populated by the node image and additionally written to as root by the global pnpm install step. Leftovers in its `_cacache/tmp` make npm fail intermittently with `EEXIST` on a tmp file, since cacache derives those names from only 4 random bytes and opens them with `wx`, e.g.:

    npm ERR! code EEXIST
    npm ERR! path /home/circleci/.npm/_cacache/tmp/298b6839

Point `npm_config_cache` at a job-private directory instead. Nothing is lost, as the jobs never save or restore an npm cache anyway.

This should fix this intermittent failure: https://app.circleci.com/pipelines/gh/argotorg/solidity/43873/workflows/9b44e941-8f49-4568-9eb6-707c21e22c95/jobs/2110003