### PR TITLE
Qualify with fmt to not rely on ADL lookup

### DIFF
--- a/libyul/optimiser/LabelIDDispenser.cpp
+++ b/libyul/optimiser/LabelIDDispenser.cpp
@@ -155,7 +155,7 @@ ASTLabelRegistry LabelIDDispenser::generateNewLabels(std::set<LabelID> const& _u
 		std::string generatedLabel = parentLabel;
 		do
 		{
-			generatedLabel = format(FMT_COMPILE("{}_{}"), parentLabel, labelSuffixes[parentLabelID]++);
+			generatedLabel = fmt::format(FMT_COMPILE("{}_{}"), parentLabel, labelSuffixes[parentLabelID]++);
 		} while (isInvalidLabel(generatedLabel, alreadyDefinedLabels, _dialect));
 
 		labels.push_back(generatedLabel);


### PR DESCRIPTION
Previously, the `format` call would only be resolved by ADL and only for fmt >= 11.
Users on e.g. Ubuntu 26.04 that don't use the vendored dependecies would hit compiler errors.

<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

Prevent compilation error on Ubuntu 26.04 with system fmt dep.
<!-- Describe the purpose of this PR. -->

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used

<!-- If AI tools were used, describe which tools and for which parts here. -->
