### PR TITLE
CI: Make macOS dependency installation resilient to cache desync

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -46,7 +46,17 @@ function validate_checksum {
   fi
 }
 
-if [ ! -f /usr/local/bin/z3 ] # if this file does not exists (cache was not restored), rebuild dependencies
+# The CI job wipes /opt/homebrew before restoring the dependency cache, trusting a
+# separate flag cache to tell it that the cache exists. The two caches expire
+# independently, so we can end up here with no brew at all.
+if ! command -v brew > /dev/null 2>&1
+then
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# A cache restore can silently drop parts of the tree, so check more than one marker.
+if [[ ! -f /usr/local/bin/z3 || ! -f /usr/local/bin/cvc5 || ! -f /opt/boost/include/boost/version.hpp ]]
 then
   brew update
   brew upgrade


### PR DESCRIPTION
The osx jobs delete /usr/local, /opt/homebrew and /opt/boost before restoring the dependency cache, based on a separate flag cache that is supposed to prove the dependency cache exists. The two caches have independent lifetimes and save_cache never refreshes an existing key, so once they drift apart the flag keeps being renewed while the payload never is. The payload then expires first and the job wipes Homebrew and dies with "brew: command not found".

Reinstall Homebrew if it is missing and check markers for boost and cvc5 as well, so both kinds of drift degrade into a rebuild instead of a failure. Touching this file also changes the checksum both cache keys are derived from, which resets the current skew.

Fixes this annoyance:  https://app.circleci.com/pipelines/github/argotorg/solidity/43919/workflows/5eb78b5f-ceb0-4553-9874-26c0fa188d61/jobs/2113087