### PR TITLE
CI: Simplify OSX dependency caching to only cover Boost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,46 +467,13 @@ commands:
       - matrix_notify_failure_unless_pr
 
   install_dependencies_osx:
-    # An extra cache key is used to only save the flag that communicates whether the cache exists.
-    # if this flag was set (the cache exist) we remove all files located in /usr/local & /opt/homebrew.
-    # With this simple trick restoring the cache is much faster. Otherwise CircleCI is generating
-    # warning messages if a file from the cache is overwriting an already existing file on disk.
-    # Restoring the cache is much faster if we remove all potentially conflicting files beforehand.
     steps:
-      - restore_cache:
-          keys:
-            - macos-dependencies-cached-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - run:
-          name: Installing dependencies / Restoring dependency cache
+          name: Ensure boost directory has correct permissions for restoring from cache
           command: |
-            if [[ -f ~/macos-dependencies-cached ]]; then
-              echo "Dependency flag exists. Removing /usr/local/, /opt/homebrew/, and /opt/boost. These directories will be restored from cache."
-
-              # CircleCI is providing the circleci cli tools via some kind of symlink magic.
-              # So we just save the original symlinks and restore them later.
-              circleci_binary_path=$(command -v circleci)
-              circleci_agent_binary_path=$(command -v circleci-agent)
-              cp "${circleci_binary_path}" /tmp/circleci
-              cp "${circleci_agent_binary_path}" /tmp/circleci-agent
-
-              # Homebrew is installed in /usr/local on intel macs, but in /opt/homebrew on apple silicon.
-              if [[ -d /opt/homebrew ]]; then
-                sudo rm -rf /opt/homebrew
-                sudo mkdir -p /opt/homebrew/bin
-                sudo chmod 777 /opt/{homebrew,homebrew/bin}
-              fi
-              # under macos /usr/local itself is read-only, so we just remove its sub-directories.
-              sudo rm -rf /usr/local/*
-              sudo mkdir -p /usr/local/bin
-              sudo chmod 777 /usr/{local,local/bin}
-
-              sudo rm -rf /opt/boost
-              sudo mkdir -p /opt/boost
-              sudo chmod 777 /opt/boost
-
-              mv /tmp/circleci "${circleci_binary_path}"
-              mv /tmp/circleci-agent "${circleci_agent_binary_path}"
-            fi
+            sudo rm -rf /opt/boost
+            sudo mkdir -p /opt/boost
+            sudo chmod 777 /opt/boost
       - restore_cache:
           keys:
             - macos-dependencies-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
@@ -515,20 +482,11 @@ commands:
       - run:
           name: Install build dependencies
           command: .circleci/osx_install_dependencies.sh
-      - run:
-          name: Mark dependencies as cached
-          command: touch ~/macos-dependencies-cached
       - save_cache:
           key: macos-dependencies-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+          # NOTE: `osx_install_dependencies.sh` installs more than boost, but we intentionally cache only boost, which takes the most time to install.
           paths:
-            # Homebrew is installed in /usr/local on intel macs, but in /opt/homebrew on apple silicon.
-            - /usr/local
-            - /opt/homebrew
             - /opt/boost
-      - save_cache:
-          key: macos-dependencies-cached-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-          paths:
-            - ~/macos-dependencies-cached
 
 defaults:
 

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -31,18 +31,18 @@
 set -eu
 
 function validate_checksum {
-  local package="$1"
-  local expected_checksum="$2"
+    local package="$1"
+    local expected_checksum="$2"
 
-  local actual_checksum
-  actual_checksum=$(sha256sum "$package")
-  if [[ $actual_checksum != "${expected_checksum}  ${package}" ]]
-  then
-    >&2 echo "ERROR: Wrong checksum for package $package."
-    >&2 echo "Actual:   $actual_checksum"
-    >&2 echo "Expected: $expected_checksum"
-    exit 1
-  fi
+    local actual_checksum
+    actual_checksum=$(sha256sum "$package")
+    if [[ $actual_checksum != "${expected_checksum}  ${package}" ]]
+    then
+        >&2 echo "ERROR: Wrong checksum for package $package."
+        >&2 echo "Actual:   $actual_checksum"
+        >&2 echo "Expected: $expected_checksum"
+        exit 1
+    fi
 }
 
 # Disable automatic `brew cleanup` after every install command. Unnecessary on CI machines.
@@ -61,19 +61,19 @@ brew install \
 # boost
 if [[ ! -f /opt/boost/include/boost/version.hpp ]]
 then
-  boost_version="1.84.0"
-  boost_package="boost_${boost_version//./_}.tar.bz2"
-  boost_dir="boost_${boost_version//./_}"
-  wget "https://archives.boost.io/release/$boost_version/source/$boost_package"
-  tar xf "$boost_package"
-  rm "$boost_package"
-  cd "$boost_dir"
-  ./bootstrap.sh --with-toolset=clang --with-libraries=thread,system,filesystem,program_options,serialization,test
-  # the default number of jobs that b2 is taking, is the number of detected available CPU threads.
-  # install boost to /opt/boost, to use it in CMake, specify Boost_ROOT
-  sudo ./b2 -a address-model=64 architecture=arm+x86 --prefix=/opt/boost install
-  cd ..
-  sudo rm -rf "$boost_dir"
+    boost_version="1.84.0"
+    boost_package="boost_${boost_version//./_}.tar.bz2"
+    boost_dir="boost_${boost_version//./_}"
+    wget "https://archives.boost.io/release/$boost_version/source/$boost_package"
+    tar xf "$boost_package"
+    rm "$boost_package"
+    cd "$boost_dir"
+    ./bootstrap.sh --with-toolset=clang --with-libraries=thread,system,filesystem,program_options,serialization,test
+    # the default number of jobs that b2 is taking, is the number of detected available CPU threads.
+    # install boost to /opt/boost, to use it in CMake, specify Boost_ROOT
+    sudo ./b2 -a address-model=64 architecture=arm+x86 --prefix=/opt/boost install
+    cd ..
+    sudo rm -rf "$boost_dir"
 fi
 
 # eldarica

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -47,15 +47,16 @@ function validate_checksum {
 
 # Disable automatic `brew cleanup` after every install command. Unnecessary on CI machines.
 export HOMEBREW_NO_INSTALL_CLEANUP=1
-brew install cmake
-brew install ccache
-brew install wget
-brew install coreutils
-brew install diffutils
-brew install grep
 # JRE is required to run eldarica solver
-brew install openjdk@11
-brew install unzip
+brew install \
+    cmake \
+    ccache \
+    wget \
+    coreutils \
+    diffutils \
+    grep \
+    openjdk@11 \
+    unzip
 
 # boost
 if [[ ! -f /opt/boost/include/boost/version.hpp ]]

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -26,8 +26,7 @@
 # ------------------------------------------------------------------------------
 
 # note that the following directories may be cached by circleci:
-# - /usr/local
-# - /opt/homebrew
+# - /opt/boost
 
 set -eu
 
@@ -46,21 +45,21 @@ function validate_checksum {
   fi
 }
 
-if [ ! -f /usr/local/bin/z3 ] # if this file does not exists (cache was not restored), rebuild dependencies
-then
-  brew update
-  brew upgrade
-  brew install cmake
-  brew install ccache
-  brew install wget
-  brew install coreutils
-  brew install diffutils
-  brew install grep
-  # JRE is required to run eldarica solver
-  brew install openjdk@11
-  brew install unzip
+brew update
+brew upgrade
+brew install cmake
+brew install ccache
+brew install wget
+brew install coreutils
+brew install diffutils
+brew install grep
+# JRE is required to run eldarica solver
+brew install openjdk@11
+brew install unzip
 
-  # boost
+# boost
+if [[ ! -f /opt/boost/include/boost/version.hpp ]]
+then
   boost_version="1.84.0"
   boost_package="boost_${boost_version//./_}.tar.bz2"
   boost_dir="boost_${boost_version//./_}"
@@ -74,36 +73,36 @@ then
   sudo ./b2 -a address-model=64 architecture=arm+x86 --prefix=/opt/boost install
   cd ..
   sudo rm -rf "$boost_dir"
-
-  # eldarica
-  eldarica_version="2.1"
-  wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /tmp/eld_binaries.zip
-  validate_checksum /tmp/eld_binaries.zip 0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c
-  unzip /tmp/eld_binaries.zip -d /tmp
-  sudo mv /tmp/eldarica/{eld,eld-client,target,eldEnv} /usr/local/bin
-  rm -rf /tmp/{eldarica,eld_binaries.zip}
-
-  #cvc5
-  cvc5_version="1.2.0"
-  cvc5_archive_name="cvc5-macOS-arm64-static"
-  wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /tmp/cvc5.zip
-  validate_checksum /tmp/cvc5.zip 57d2d4855af3f3865110a254e415098b4e150a655f297010e27eb292f48f7da7
-  sudo unzip -j /tmp/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/local/bin
-  rm -f /tmp/cvc5.zip
-
-  # z3
-  z3_version="4.13.3"
-  z3_archive_name="z3-${z3_version}-arm64-osx-13.7"
-  wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_archive_name}.zip" -O /tmp/z3.zip
-  validate_checksum /tmp/z3.zip 2b2c6e23ff5488722bc93002e04c6d6f60d621af9d345f2e05a8691b40280e53
-  sudo unzip -j /tmp/z3.zip "${z3_archive_name}/bin/z3" -d /usr/local/bin
-  rm -f /tmp/z3.zip
-
-  # evmone
-  evmone_version="0.22.0"
-  evmone_package="evmone-${evmone_version}-darwin-arm64.tar.gz"
-  wget "https://github.com/ipsilon/evmone/releases/download/v${evmone_version}/${evmone_package}"
-  validate_checksum "$evmone_package" 3ff5633e49ae3726dc094c7c9819440c11d04c8036bc27f45a4385120951599c
-  sudo tar xzpf "$evmone_package" -C /usr/local
-  rm "$evmone_package"
 fi
+
+# eldarica
+eldarica_version="2.1"
+wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /tmp/eld_binaries.zip
+validate_checksum /tmp/eld_binaries.zip 0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c
+unzip /tmp/eld_binaries.zip -d /tmp
+sudo mv /tmp/eldarica/{eld,eld-client,target,eldEnv} /usr/local/bin
+rm -rf /tmp/{eldarica,eld_binaries.zip}
+
+#cvc5
+cvc5_version="1.2.0"
+cvc5_archive_name="cvc5-macOS-arm64-static"
+wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /tmp/cvc5.zip
+validate_checksum /tmp/cvc5.zip 57d2d4855af3f3865110a254e415098b4e150a655f297010e27eb292f48f7da7
+sudo unzip -j /tmp/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/local/bin
+rm -f /tmp/cvc5.zip
+
+# z3
+z3_version="4.13.3"
+z3_archive_name="z3-${z3_version}-arm64-osx-13.7"
+wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_archive_name}.zip" -O /tmp/z3.zip
+validate_checksum /tmp/z3.zip 2b2c6e23ff5488722bc93002e04c6d6f60d621af9d345f2e05a8691b40280e53
+sudo unzip -j /tmp/z3.zip "${z3_archive_name}/bin/z3" -d /usr/local/bin
+rm -f /tmp/z3.zip
+
+# evmone
+evmone_version="0.22.0"
+evmone_package="evmone-${evmone_version}-darwin-arm64.tar.gz"
+wget "https://github.com/ipsilon/evmone/releases/download/v${evmone_version}/${evmone_package}"
+validate_checksum "$evmone_package" 3ff5633e49ae3726dc094c7c9819440c11d04c8036bc27f45a4385120951599c
+sudo tar xzpf "$evmone_package" -C /usr/local
+rm "$evmone_package"

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -45,8 +45,8 @@ function validate_checksum {
   fi
 }
 
-brew update
-brew upgrade
+# Disable automatic `brew cleanup` after every install command. Unnecessary on CI machines.
+export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew install cmake
 brew install ccache
 brew install wget


### PR DESCRIPTION
Previously, we were using complicated two-level scheme for caching dependencies on OSX CI machines.
Here we only cache the Boost installation, which is much smaller than whole of `/usr/local` and `opt/homebrew`.
Downloading, compiling and installing boost is the most expensive part of preparing the dependencies.

All other dependencies are now always installed unconditionally. This could be optimize in the future.