### PR TITLE
SSA CFG: Fix internal error when a call return label is materialized before its call

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -250,6 +250,15 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	std::visit(solidity::util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
+AbstractAssembly::LabelID CodeTransform::returnLabel(InstId const _instId)
+{
+	yulAssert(m_cfg.callPayload(_instId).canContinue, "Return label requested for a call that cannot continue.");
+	auto const [it, inserted] = m_returnLabels.try_emplace(_instId, 0);
+	if (inserted)
+		it->second = m_assembly.newLabelId();
+	return it->second;
+}
+
 void CodeTransform::operator()(InstId _instId, ShuffleTrace const& _operationShuffle)
 {
 	SSACFG::Inst const& _inst = m_cfg.inst(_instId);
@@ -258,11 +267,7 @@ void CodeTransform::operator()(InstId _instId, ShuffleTrace const& _operationShu
 	bool const hasReturnLabel = isCall && m_cfg.callPayload(_instId).canContinue;
 
 	if (hasReturnLabel)
-	{
-		auto const [it, inserted] = m_returnLabels.try_emplace(_instId, 0);
-		yulAssert(inserted, "Call sites should be unique.");
-		it->second = m_assembly.newLabelId();
-	}
+		returnLabel(_instId);
 
 	// check that the assembly stack height corresponds to the stack size before shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
@@ -536,12 +541,8 @@ void CodeTransform::emit(ShuffleOp const& _op)
 				m_assembly.appendInstruction(evmasm::Instruction::CODESIZE);
 			return;
 		case StackSlot::Kind::FunctionCallReturnLabel:
-		{
-			auto const instId = m_callSites.instId(_op.slot.functionCallReturnLabel());
-			yulAssert(m_returnLabels.count(instId), "FunctionCallReturnLabel not pre-registered before shuffle.");
-			m_assembly.appendLabelReference(m_returnLabels.at(instId));
+			m_assembly.appendLabelReference(returnLabel(m_callSites.instId(_op.slot.functionCallReturnLabel())));
 			return;
-		}
 		case StackSlot::Kind::FunctionReturnLabel:
 			yulAssert(false, "Cannot produce function return label.");
 		}

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -84,6 +84,9 @@ private:
 	/// stores it into its memory slot
 	void spillStore(InstId _value);
 
+	/// The return label of the call `_instId`, created on first use
+	AbstractAssembly::LabelID returnLabel(InstId _instId);
+
 	AbstractAssembly& m_assembly;
 	BuiltinContext& m_builtinContext;
 	ControlFlowGraphs const& m_controlFlow;

--- a/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/input.json
+++ b/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/input.json
@@ -1,0 +1,19 @@
+{
+    "language": "Yul",
+    "sources": {
+        "A": {
+            "content": "object \"C\" {\n    code {\n        {\n            switch calldataload(0)\n            case 0x12065fe0 {\n                switch returndatasize()\n                default {}\n                entry()\n            }\n        }\n        function getBalan() -> var {}\n        function literal_a() -> memPtr {}\n        function entry()\n        {\n            let _1 := and(resolve(literal_a()), 1)\n            process(_1)\n        }\n        function literal_b() -> memPtr {}\n        function resolve(key) -> var {}\n        function process(target) { pop(distribute(0)) }\n        function checked_add(var_a, var_b) -> var {}\n        function checked_sub(var_a, var_b) -> var {}\n        function distribute(addr) -> var\n        {\n            let _1 := and(0, 0)\n            let _2 := and(resolve(literal_b()), 1)\n            switch 0\n            case 0 {}\n            let _3 := and(resolve(literal_c()), 1)\n            let bal := getBalan()\n            let total := 0\n            pop(staticcall(0, _1, 0, 0, 0, 0))\n            let memPtr := mload(64)\n            let _4 := add(array_size(0), not(31))\n            let i := 0\n            for {} lt(i, _4) { i := add(i, 0) }\n            {}\n            let deposit := 0\n            let count := 0\n            let minimum := 0\n            let i2 := 0\n            for {} lt(i2, 0) { i2 := add(i2, 0) }\n            {\n                if iszero(count)\n                {\n                    count := 0\n                    deposit := 0\n                    pop(staticcall(0, _3, 0, sub(encode(add(0, 0), 0), 0), 0, 32))\n                    minimum := 0\n                }\n                let cond := iszero(0)\n                if iszero(0)\n                {\n                    cond := lt(checked_sub(bal, total), minimum)\n                }\n                if cond {}\n                pop(call(0, _2, 0, 0, sub(encode(add(0, 0), deposit), 0), 0, 32))\n                total := checked_add(total, 0)\n            }\n            for {} lt(0, 0) {}\n            {\n                pop(mload(add(mload(elem_addr(memPtr, 0)), 32)))\n            }\n        }\n        function literal_c() -> memPtr {}\n        function array_size(length) -> size {}\n        function elem_addr(base, index) -> addr { revert(0, 0) }\n        function encode(head, value) -> tail {}\n    }\n}\n"
+        }
+    },
+    "settings": {
+        "experimental": true,
+        "viaSSACFG": true,
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "evm.bytecode.object"
+                ]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/output.json
+++ b/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/output.json
@@ -1,21 +1,33 @@
 {
+    "contracts": {
+        "A": {
+            "C": {
+                "evm": {
+                    "bytecode": {
+                        "object": "<BYTECODE REMOVED>"
+                    }
+                }
+            }
+        }
+    },
     "errors": [
         {
             "component": "general",
-            "formattedMessage": "Uncaught exception:
-/solidity/libyul/backends/evm/ssa/CodeTransform.cpp(541): Throw in function void solidity::yul::ssa::CodeTransform::emit(const solidity::yul::ssa::ShuffleOp&)
-Dynamic exception type: boost::wrapexcept<solidity::yul::YulAssertion>
-std::exception::what: FunctionCallReturnLabel not pre-registered before shuffle.
-[solidity::util::tag_comment*] = FunctionCallReturnLabel not pre-registered before shuffle.
+            "formattedMessage": "Warning: \"switch\" statement with only a default case.
+ --> A:6:17:
+  |
+6 |                 switch returndatasize()
+  |                 ^ (Relevant source part starts here and spans across multiple lines).
+
 ",
-            "message": "Uncaught exception:
-/solidity/libyul/backends/evm/ssa/CodeTransform.cpp(541): Throw in function void solidity::yul::ssa::CodeTransform::emit(const solidity::yul::ssa::ShuffleOp&)
-Dynamic exception type: boost::wrapexcept<solidity::yul::YulAssertion>
-std::exception::what: FunctionCallReturnLabel not pre-registered before shuffle.
-[solidity::util::tag_comment*] = FunctionCallReturnLabel not pre-registered before shuffle.
-",
-            "severity": "error",
-            "type": "InternalCompilerError"
+            "message": "\"switch\" statement with only a default case.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 165,
+                "file": "A",
+                "start": 115
+            },
+            "type": "Warning"
         }
     ]
 }

--- a/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/output.json
+++ b/test/cmdlineTests/standard_yul_via_ssa_cfg_return_label_before_call/output.json
@@ -1,0 +1,21 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Uncaught exception:
+/solidity/libyul/backends/evm/ssa/CodeTransform.cpp(541): Throw in function void solidity::yul::ssa::CodeTransform::emit(const solidity::yul::ssa::ShuffleOp&)
+Dynamic exception type: boost::wrapexcept<solidity::yul::YulAssertion>
+std::exception::what: FunctionCallReturnLabel not pre-registered before shuffle.
+[solidity::util::tag_comment*] = FunctionCallReturnLabel not pre-registered before shuffle.
+",
+            "message": "Uncaught exception:
+/solidity/libyul/backends/evm/ssa/CodeTransform.cpp(541): Throw in function void solidity::yul::ssa::CodeTransform::emit(const solidity::yul::ssa::ShuffleOp&)
+Dynamic exception type: boost::wrapexcept<solidity::yul::YulAssertion>
+std::exception::what: FunctionCallReturnLabel not pre-registered before shuffle.
+[solidity::util::tag_comment*] = FunctionCallReturnLabel not pre-registered before shuffle.
+",
+            "severity": "error",
+            "type": "InternalCompilerError"
+        }
+    ]
+}


### PR DESCRIPTION
`--via-ssa-cfg` aborts with `FunctionCallReturnLabel not pre-registered before
shuffle` on some inputs (found on the rocketpool-deposit-pool benchmark).

The code transform allocated a call's return label ID when it emitted the call, and asserted if a shuffle asked for the label before that. But a layout can demand a return label earlier than the call on a block that is emitted first.

The fix allocates return labels lazily, on first use, via a single accessor used by both the call-emission and the shuffle-push sites.

Also adds the first Yul-level file-based coverage of the SSA CFG code transform: `ObjectCompilerTest` gains a `viaSSACFG` setting, and the reproducer goes in as an object-compiler test. Without the fix that test fails with the assertion above; with it, it compiles.
