### PR TITLE
Fix Docs: Grammar fix from recommend to recommended

### DIFF
--- a/docs/contracts/transient-storage.rst
+++ b/docs/contracts/transient-storage.rst
@@ -165,7 +165,7 @@ reentrancy lock, since failing to do so, will restrict your contract to only one
 within a transaction, preventing its use in complex composed transactions,
 which have been a cornerstone for complex applications on chain.
 
-It is recommend to generally always clear transient storage completely at the end of a call
+It is recommended to always clear transient storage completely at the end of a call
 into your smart contract to avoid these kinds of issues and to simplify
 the analysis of the behaviour of your contract within complex transactions.
 Check the `Security Considerations section of EIP-1153 <https://eips.ethereum.org/EIPS/eip-1153#security-considerations>`_


### PR DESCRIPTION
## Description

Fixes a grammar mistake in the `Composability of Smart Contracts and the Caveats of Transient Storage` section in `docs/contracts/transient-storage.rst`:
the current sentence `_It is recommend to generally always clear_` is changed to the correct grammar `_It is recommended to always clear_`.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

- [ ] No AI tools were used

The grammar mistake was discovered and fixed independently.