### PR TITLE
Fix @param names that do not match the declaration

### DIFF
--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -196,7 +196,7 @@ protected:
 
 	/// Add all assembly items from given JSON array. This function imports the items by iterating through
 	/// the code array. This method only works on clean Assembly objects that don't have any items defined yet.
-	/// @param _json JSON array that contains assembly items (e.g. json['.code'])
+	/// @param _code JSON array that contains assembly items (e.g. json['.code'])
 	/// @param _sourceList List of source names.
 	void importAssemblyItemsFromJSON(Json const& _code, std::vector<std::string> const& _sourceList);
 

--- a/libsolidity/codegen/ArrayUtils.h
+++ b/libsolidity/codegen/ArrayUtils.h
@@ -106,8 +106,8 @@ public:
 private:
 	/// Adds the given number of bytes to a storage byte offset counter and also increments
 	/// the storage offset if adding this number again would increase the counter over 32.
-	/// @param byteOffsetPosition the stack offset of the storage byte offset
-	/// @param storageOffsetPosition the stack offset of the storage slot offset
+	/// @param _byteOffsetPosition the stack offset of the storage byte offset
+	/// @param _storageOffsetPosition the stack offset of the storage slot offset
 	void incrementByteOffset(unsigned _byteSize, unsigned _byteOffsetPosition, unsigned _storageOffsetPosition) const;
 
 	CompilerContext& m_context;

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -299,7 +299,7 @@ public:
 	/// Appends code that copies the code of the given contract to memory.
 	/// Stack pre: Memory position
 	/// Stack post: Updated memory position
-	/// @param creation if true, copies creation code, if false copies runtime code.
+	/// @param _creationCode if true, copies creation code, if false copies runtime code.
 	/// @note the contract has to be compiled already, so beware of cyclic dependencies!
 	void copyContractCodeToMemory(ContractDefinition const& contract, bool _creationCode);
 

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -597,7 +597,7 @@ void iterateReplacingWindow(std::vector<T>& _vector, F const& _f)
 bool passesAddressChecksum(std::string const& _str, bool _strict);
 
 /// @returns the checksummed version of an address
-/// @param hex strings that look like an address
+/// @param _addr hex string that looks like an address
 std::string getChecksummedAddress(std::string const& _addr);
 
 bool isValidHex(std::string_view _string);

--- a/libsolutil/StringUtils.h
+++ b/libsolutil/StringUtils.h
@@ -189,7 +189,7 @@ std::string prefixLines(
 /// @param _trimPrefix If true, the function avoids introducing trailing whitespace on empty lines.
 ///     This is achieved by removing trailing spaces from the prefix on such lines.
 ///     Note that tabs and newlines are not removed, only spaces are.
-/// @param _finalNewline If true, an extra \n will be printed at the end of @a _input if it does
+/// @param _ensureFinalNewline If true, an extra \n will be printed at the end of @a _input if it does
 ///     not already end with one.
 void printPrefixed(
 	std::ostream& _output,


### PR DESCRIPTION
## Description

Ran doxygen over libsolidity and libsolutil and five `@param` names came back unmatched against the declaration below them. Most are the missing leading underscore, `importAssemblyItemsFromJSON` still uses the old name of its first argument, and `printPrefixed` documents `_finalNewline` where the argument is `_ensureFinalNewline`. Doxygen drops unmatched names quietly so none of it shows up in a build. I left alone the blocks where the documented parameter is gone from the signature entirely, that one needs someone who knows whether the line goes or the code moved.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

Claude Code (claude-opus-5) was used to scan the headers for `@param` names that do not match the declaration under them, and to draft this description. Every change here was checked by hand against the declaration.
