### PR TITLE
Fix constant value function arithmetic mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ Compiler Features:
 Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
+* Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 * Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
 * Yul Optimizer: Fix incorrect removal of `returndatacopy()` operations referencing a stale result of `returndatasize()`.

--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -18,11 +18,14 @@
 
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/codegen/ir/Common.h>
+
 #include <libsolidity/codegen/ir/IRGenerationContext.h>
 
 #include <libsolutil/CommonIO.h>
 
 #include <libyul/AsmPrinter.h>
+
+#include <fmt/format.h>
 
 using namespace solidity::langutil;
 using namespace solidity::frontend;
@@ -103,10 +106,20 @@ std::string IRNames::libraryAddressImmutable()
 	return "library_deploy_address";
 }
 
-std::string IRNames::constantValueFunction(VariableDeclaration const& _constant)
+std::string IRNames::constantValueFunction(VariableDeclaration const& _constant, Arithmetic const _arithmetic)
 {
-	solAssert(_constant.isConstant(), "");
-	return "constant_" + _constant.name() + "_" + std::to_string(_constant.id());
+	solAssert(_constant.isConstant());
+	std::string postfix = [_arithmetic]() -> std::string {
+		switch (_arithmetic)
+		{
+		case Arithmetic::Checked:
+			return "checked";
+		case Arithmetic::Wrapping:
+			return "wrapping";
+		}
+		unreachable();
+	}();
+	return fmt::format("constant_{}_{}_{}", _constant.name(), _constant.id(), postfix);
 }
 
 std::string IRNames::localVariable(VariableDeclaration const& _declaration)

--- a/libsolidity/codegen/ir/Common.h
+++ b/libsolidity/codegen/ir/Common.h
@@ -59,7 +59,7 @@ struct IRNames
 	static std::string internalDispatch(YulArity const& _arity);
 	static std::string constructor(ContractDefinition const& _contract);
 	static std::string libraryAddressImmutable();
-	static std::string constantValueFunction(VariableDeclaration const& _constant);
+	static std::string constantValueFunction(VariableDeclaration const& _constant, Arithmetic _arithmetic);
 	static std::string localVariable(VariableDeclaration const& _declaration);
 	static std::string localVariable(Expression const& _expression);
 	/// @returns the variable name that can be used to inspect the success or failure of an external

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -138,9 +138,6 @@ public:
 	langutil::EVMVersion evmVersion() const { return m_evmVersion; }
 	ExecutionContext executionContext() const { return m_executionContext; }
 
-	void setArithmetic(Arithmetic _value) { m_arithmetic = _value; }
-	Arithmetic arithmetic() const { return m_arithmetic; }
-
 	ABIFunctions abiFunctions();
 
 	RevertStrings revertStrings() const { return m_revertStrings; }
@@ -179,8 +176,6 @@ private:
 	std::map<VariableDeclaration const*, std::pair<u256, unsigned>> m_stateVariables;
 	MultiUseYulFunctionCollector m_functions;
 	size_t m_varCounter = 0;
-	/// Whether to use checked or wrapping arithmetic.
-	Arithmetic m_arithmetic = Arithmetic::Checked;
 
 	/// Flag indicating whether any memory-unsafe inline assembly block was seen.
 	bool m_memoryUnsafeInlineAssemblySeen = false;

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -588,7 +588,7 @@ std::string IRGenerator::generateGetter(VariableDeclaration const& _varDecl)
 				dispenseLocationComment(m_context.mostDerivedContract())
 			)
 			("functionName", functionName)
-			("constantValueFunction", IRGeneratorForStatements(m_context, m_utils, m_optimiserSettings).constantValueFunction(_varDecl))
+			("constantValueFunction", IRGeneratorForStatements(m_context, m_utils, m_optimiserSettings).constantValueFunction(_varDecl, Arithmetic::Checked))
 			("ret", suffixedVariableNameList("ret_", 0, _varDecl.type()->sizeOnStack()))
 			.render();
 		}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -354,12 +354,10 @@ std::string IRGeneratorForStatements::constantValueFunction(VariableDeclaration 
 			IRGeneratorForStatements generator(m_context, m_utils, m_optimiserSettings);
 			// The constant's expression is re-evaluated at each use site and must use the
 			// arithmetic mode of the context it is referenced from.
-			Arithmetic previousArithmetic = m_context.arithmetic();
-			m_context.setArithmetic(_arithmetic);
+			generator.m_currentArithmeticMode = _arithmetic;
 			solAssert(_constant.value());
 			Type const& constantType = *_constant.type();
 			templ("value", generator.evaluateExpression(*_constant.value(), constantType).commaSeparatedList());
-			m_context.setArithmetic(previousArithmetic);
 			templ("code", generator.code());
 			templ("ret", IRVariable("ret", constantType).commaSeparatedList());
 
@@ -570,8 +568,8 @@ bool IRGeneratorForStatements::visit(Block const& _block)
 {
 	if (_block.unchecked())
 	{
-		solAssert(m_context.arithmetic() == Arithmetic::Checked);
-		m_context.setArithmetic(Arithmetic::Wrapping);
+		solAssert(m_currentArithmeticMode == Arithmetic::Checked);
+		m_currentArithmeticMode = Arithmetic::Wrapping;
 	}
 	return true;
 }
@@ -580,8 +578,8 @@ void IRGeneratorForStatements::endVisit(Block const& _block)
 {
 	if (_block.unchecked())
 	{
-		solAssert(m_context.arithmetic() == Arithmetic::Wrapping);
-		m_context.setArithmetic(Arithmetic::Checked);
+		solAssert(m_currentArithmeticMode == Arithmetic::Wrapping);
+		m_currentArithmeticMode = Arithmetic::Checked;
 	}
 }
 
@@ -758,7 +756,7 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 			IRVariable modifiedValue(m_context.newYulVariable(), resultType);
 			IRVariable originalValue = readFromLValue(*m_currentLValue);
 
-			bool checked = m_context.arithmetic() == Arithmetic::Checked;
+			bool checked = m_currentArithmeticMode == Arithmetic::Checked;
 			define(modifiedValue) <<
 				(op == Token::Inc ?
 					(checked ? m_utils.incrementCheckedFunction(resultType) : m_utils.incrementWrappingFunction(resultType)) :
@@ -781,7 +779,7 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 		{
 			IntegerType const& intType = *dynamic_cast<IntegerType const*>(&resultType);
 			define(_unaryOperation) << (
-				m_context.arithmetic() == Arithmetic::Checked ?
+				m_currentArithmeticMode == Arithmetic::Checked ?
 				m_utils.negateNumberCheckedFunction(intType) :
 				m_utils.negateNumberWrappingFunction(intType)
 			) << "(" << IRVariable(_unaryOperation.subExpression()).name() << ")\n";
@@ -921,7 +919,7 @@ bool IRGeneratorForStatements::visit(BinaryOperation const& _binOp)
 		IRVariable left = convert(_binOp.leftExpression(), *commonType);
 		IRVariable right = convert(_binOp.rightExpression(), *type(_binOp.rightExpression()).mobileType());
 
-		if (m_context.arithmetic() == Arithmetic::Wrapping)
+		if (m_currentArithmeticMode == Arithmetic::Wrapping)
 			define(_binOp) << m_utils.wrappingIntExpFunction(
 				dynamic_cast<IntegerType const&>(left.type()),
 				dynamic_cast<IntegerType const&>(right.type())
@@ -2587,7 +2585,7 @@ void IRGeneratorForStatements::handleVariableReference(
 )
 {
 	if ((_variable.isStateVariable() || _variable.isFileLevelVariable()) && _variable.isConstant())
-		define(_referencingExpression) << constantValueFunction(_variable, m_context.arithmetic()) << "()\n";
+		define(_referencingExpression) << constantValueFunction(_variable, m_currentArithmeticMode) << "()\n";
 	else if (_variable.isStateVariable() && _variable.immutable())
 		setLValue(_referencingExpression, IRLValue{
 			*_variable.annotation().type,
@@ -3035,7 +3033,7 @@ std::string IRGeneratorForStatements::binaryOperation(
 		);
 		IntegerType const* type = dynamic_cast<IntegerType const*>(&_type);
 		solAssert(type);
-		bool checked = m_context.arithmetic() == Arithmetic::Checked;
+		bool checked = m_currentArithmeticMode == Arithmetic::Checked;
 		switch (_operator)
 		{
 		case Token::Add:
@@ -3333,11 +3331,11 @@ void IRGeneratorForStatements::generateLoop(
 	appendCode() << "} 1 {\n";
 	if (_loopExpression)
 	{
-		Arithmetic previousArithmetic = m_context.arithmetic();
+		Arithmetic previousArithmeticMode = m_currentArithmeticMode;
 		if (m_optimiserSettings.simpleCounterForLoopUncheckedIncrement && _isSimpleCounterLoop)
-			m_context.setArithmetic(Arithmetic::Wrapping);
+			m_currentArithmeticMode = Arithmetic::Wrapping;
 		_loopExpression->accept(*this);
-		m_context.setArithmetic(previousArithmetic);
+		m_currentArithmeticMode = previousArithmeticMode;
 	}
 	appendCode() << "}\n";
 	appendCode() << "{\n";

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -336,11 +336,11 @@ IRVariable IRGeneratorForStatements::evaluateExpression(Expression const& _expre
 	}
 }
 
-std::string IRGeneratorForStatements::constantValueFunction(VariableDeclaration const& _constant)
+std::string IRGeneratorForStatements::constantValueFunction(VariableDeclaration const& _constant, Arithmetic const _arithmetic)
 {
 	try
 	{
-		std::string functionName = IRNames::constantValueFunction(_constant);
+		std::string functionName = IRNames::constantValueFunction(_constant, _arithmetic);
 		return m_context.functionCollector().createFunction(functionName, [&] {
 			Whiskers templ(R"(
 				<sourceLocationComment>
@@ -352,9 +352,14 @@ std::string IRGeneratorForStatements::constantValueFunction(VariableDeclaration 
 			templ("sourceLocationComment", dispenseLocationComment(_constant, m_context));
 			templ("functionName", functionName);
 			IRGeneratorForStatements generator(m_context, m_utils, m_optimiserSettings);
+			// The constant's expression is re-evaluated at each use site and must use the
+			// arithmetic mode of the context it is referenced from.
+			Arithmetic previousArithmetic = m_context.arithmetic();
+			m_context.setArithmetic(_arithmetic);
 			solAssert(_constant.value());
 			Type const& constantType = *_constant.type();
 			templ("value", generator.evaluateExpression(*_constant.value(), constantType).commaSeparatedList());
+			m_context.setArithmetic(previousArithmetic);
 			templ("code", generator.code());
 			templ("ret", IRVariable("ret", constantType).commaSeparatedList());
 
@@ -2582,7 +2587,7 @@ void IRGeneratorForStatements::handleVariableReference(
 )
 {
 	if ((_variable.isStateVariable() || _variable.isFileLevelVariable()) && _variable.isConstant())
-		define(_referencingExpression) << constantValueFunction(_variable) << "()\n";
+		define(_referencingExpression) << constantValueFunction(_variable, m_context.arithmetic()) << "()\n";
 	else if (_variable.isStateVariable() && _variable.immutable())
 		setLValue(_referencingExpression, IRLValue{
 			*_variable.annotation().type,

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -252,6 +252,8 @@ private:
 	YulUtilFunctions& m_utils;
 	std::optional<IRLValue> m_currentLValue;
 	OptimiserSettings m_optimiserSettings;
+	/// Whether to use checked or wrapping arithmetic.
+	Arithmetic m_currentArithmeticMode = Arithmetic::Checked;
 };
 
 }

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -105,8 +105,8 @@ public:
 	}
 
 	/// @returns the name of a function that computes the value of the given constant
-	/// and also generates the function.
-	std::string constantValueFunction(VariableDeclaration const& _constant);
+	/// in the given arithmetic mode and also generates the function.
+	std::string constantValueFunction(VariableDeclaration const& _constant, Arithmetic _arithmetic);
 
 	void endVisit(VariableDeclarationStatement const& _variableDeclaration) override;
 	bool visit(Conditional const& _conditional) override;

--- a/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
@@ -315,7 +315,7 @@ object \"C_54\" {
             }
 
             /// @src 0:96:129  \"int public constant constVar = 41\"
-            function constant_constVar_5() -> ret {
+            function constant_constVar_5_checked() -> ret {
                 /// @src 0:127:129  \"41\"
                 let expr_4 := 0x29
                 let _1 := convert_t_rational_41_by_1_to_t_int256(expr_4)
@@ -326,7 +326,7 @@ object \"C_54\" {
             /// @ast-id 5
             /// @src 0:96:129  \"int public constant constVar = 41\"
             function getter_fun_constVar_5() -> ret_0 {
-                ret_0 := constant_constVar_5()
+                ret_0 := constant_constVar_5_checked()
             }
             /// @src 0:79:510  \"contract C...\"
 
@@ -377,7 +377,7 @@ object \"C_54\" {
                 var__23 := zero_t_int256_2
 
                 /// @src 0:322:330  \"constVar\"
-                let expr_25 := constant_constVar_5()
+                let expr_25 := constant_constVar_5_checked()
                 /// @src 0:333:341  \"immutVar\"
                 let _3 := loadimmutable(\"8\")
                 let expr_26 := _3
@@ -1151,7 +1151,7 @@ object \"D_72\" {
             }
 
             /// @src 0:96:129  \"int public constant constVar = 41\"
-            function constant_constVar_5() -> ret {
+            function constant_constVar_5_checked() -> ret {
                 /// @src 0:127:129  \"41\"
                 let expr_4 := 0x29
                 let _1 := convert_t_rational_41_by_1_to_t_int256(expr_4)
@@ -1162,7 +1162,7 @@ object \"D_72\" {
             /// @ast-id 5
             /// @src 0:96:129  \"int public constant constVar = 41\"
             function getter_fun_constVar_5() -> ret_0 {
-                ret_0 := constant_constVar_5()
+                ret_0 := constant_constVar_5_checked()
             }
             /// @src 1:91:181  \"contract D is C(3)...\"
 
@@ -1213,7 +1213,7 @@ object \"D_72\" {
                 var__23 := zero_t_int256_2
 
                 /// @src 0:322:330  \"constVar\"
-                let expr_25 := constant_constVar_5()
+                let expr_25 := constant_constVar_5_checked()
                 /// @src 0:333:341  \"immutVar\"
                 let _3 := loadimmutable(\"8\")
                 let expr_26 := _3

--- a/test/libsolidity/semanticTests/constants/constant_exponentiation_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_exponentiation_checked_unchecked.sol
@@ -4,8 +4,6 @@ contract C {
     function a() external pure returns (uint8) { return x; }
     function b() external pure returns (uint8) { unchecked { return x; } }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> FAILURE, hex"4e487b71", 0x11
-// b() -> FAILURE, hex"4e487b71", 0x11
+// b() -> 0

--- a/test/libsolidity/semanticTests/constants/constant_exponentiation_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_exponentiation_checked_unchecked.sol
@@ -1,0 +1,11 @@
+uint8 constant x = uint8(16) ** 2;
+
+contract C {
+    function a() external pure returns (uint8) { return x; }
+    function b() external pure returns (uint8) { unchecked { return x; } }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> FAILURE, hex"4e487b71", 0x11
+// b() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_public_getter_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_public_getter_checked_unchecked.sol
@@ -4,8 +4,6 @@ contract C {
     // generated.
     function f() external pure returns (uint8) { unchecked { return X; } }
 }
-// ====
-// compileViaYul: true
 // ----
 // X() -> FAILURE, hex"4e487b71", 0x11
-// f() -> FAILURE, hex"4e487b71", 0x11
+// f() -> 0x90

--- a/test/libsolidity/semanticTests/constants/constant_public_getter_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_public_getter_checked_unchecked.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint8 public constant X = uint8(200) + 200;
+    // The auto-generated getter requests X's value before any function body is
+    // generated.
+    function f() external pure returns (uint8) { unchecked { return X; } }
+}
+// ====
+// compileViaYul: true
+// ----
+// X() -> FAILURE, hex"4e487b71", 0x11
+// f() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_read_checked_then_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_checked_then_unchecked.sol
@@ -5,8 +5,6 @@ contract C {
     function a() external pure returns (uint8) { return x; }
     function b() external pure returns (uint8) { unchecked { return x; } }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> FAILURE, hex"4e487b71", 0x11
-// b() -> FAILURE, hex"4e487b71", 0x11
+// b() -> 0x90

--- a/test/libsolidity/semanticTests/constants/constant_read_checked_then_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_checked_then_unchecked.sol
@@ -1,0 +1,12 @@
+uint8 constant x = uint8(200) + 200;
+
+contract C {
+    // a() has the lower selector and is generated first.
+    function a() external pure returns (uint8) { return x; }
+    function b() external pure returns (uint8) { unchecked { return x; } }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> FAILURE, hex"4e487b71", 0x11
+// b() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_read_unchecked_then_checked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_unchecked_then_checked.sol
@@ -5,8 +5,6 @@ contract C {
     function a() external pure returns (uint8) { unchecked { return x; } }
     function b() external pure returns (uint8) { return x; }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> 0x90
-// b() -> 0x90
+// b() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_read_unchecked_then_checked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_unchecked_then_checked.sol
@@ -1,0 +1,12 @@
+uint8 constant x = uint8(200) + 200;
+
+contract C {
+    // a() has the lower selector and is generated first.
+    function a() external pure returns (uint8) { unchecked { return x; } }
+    function b() external pure returns (uint8) { return x; }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> 0x90
+// b() -> 0x90

--- a/test/libsolidity/semanticTests/constants/constant_read_via_external_call_from_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_via_external_call_from_unchecked.sol
@@ -1,0 +1,17 @@
+uint8 constant x = uint8(16) ** 2;
+
+contract C {
+    function a() external pure returns (uint8) { return x; }
+    function b() external pure returns (uint8) { unchecked { return x; } }
+    function c() external view returns (uint8) {
+        unchecked {
+            return this.a();
+        }
+    }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> FAILURE, hex"4e487b71", 0x11
+// b() -> FAILURE, hex"4e487b71", 0x11
+// c() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_read_via_external_call_from_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_read_via_external_call_from_unchecked.sol
@@ -9,9 +9,7 @@ contract C {
         }
     }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> FAILURE, hex"4e487b71", 0x11
-// b() -> FAILURE, hex"4e487b71", 0x11
+// b() -> 0
 // c() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_referencing_constant_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_referencing_constant_checked_unchecked.sol
@@ -1,0 +1,14 @@
+uint8 constant B = uint8(200) + 200;
+uint8 constant A = B;
+
+contract C {
+    // B is never read from an unchecked block, but the unchecked read of A
+    // requests B's value transitively.
+    function a() external pure returns (uint8) { unchecked { return A; } }
+    function b() external pure returns (uint8) { return B; }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> 0x90
+// b() -> 0x90

--- a/test/libsolidity/semanticTests/constants/constant_referencing_constant_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_referencing_constant_checked_unchecked.sol
@@ -7,8 +7,6 @@ contract C {
     function a() external pure returns (uint8) { unchecked { return A; } }
     function b() external pure returns (uint8) { return B; }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> 0x90
-// b() -> 0x90
+// b() -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/constants/constant_unary_minus_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_unary_minus_checked_unchecked.sol
@@ -4,8 +4,6 @@ contract C {
     function a() external pure returns (int8) { return x; }
     function b() external pure returns (int8) { unchecked { return x; } }
 }
-// ====
-// compileViaYul: true
 // ----
 // a() -> FAILURE, hex"4e487b71", 0x11
-// b() -> FAILURE, hex"4e487b71", 0x11
+// b() -> -128

--- a/test/libsolidity/semanticTests/constants/constant_unary_minus_checked_unchecked.sol
+++ b/test/libsolidity/semanticTests/constants/constant_unary_minus_checked_unchecked.sol
@@ -1,0 +1,11 @@
+int8 constant x = -int8(-128);
+
+contract C {
+    function a() external pure returns (int8) { return x; }
+    function b() external pure returns (int8) { unchecked { return x; } }
+}
+// ====
+// compileViaYul: true
+// ----
+// a() -> FAILURE, hex"4e487b71", 0x11
+// b() -> FAILURE, hex"4e487b71", 0x11


### PR DESCRIPTION
Fixes https://github.com/argotorg/solidity/issues/16967 

The value of constants is, prior to the fix, evaluated based on a single helper that didn't contain the arithmethic mode (checked/unchecked) in its cache key string.

- added tests which show the inconsistent behavior
- the `IRNames::constantValueFunction` gets the arithmetic mode as argument and derives the helper's function name from it (coinciding with the cache key)
- additionally (and optionally, not strictly required for the fix) refactored the `IRGenerationContext` to no longer contain the arithmetic mode, it now lives in the statement generator:
  - the generation context is shared
  - moving the arithmetic mode into the rather short-lived `IRGeneratorForStatements`, which in particular makes it impossible for the mode to leak between generators