### PR TITLE
CLI: reject --model-checker-ext-calls in unsupported input modes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
+* Commandline Interface: Reject `--model-checker-ext-calls` in unsupported input modes instead of silently ignoring it.
 * Type Checker: Report an unimplemented feature error instead of ICE when a variable of a fixed point type is accessed in inline assembly.
 * Yul Optimizer: Fix incorrect removal of `returndatacopy()` operations referencing a stale result of `returndatasize()`.
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -1061,6 +1061,7 @@ void CommandLineParser::processArgs()
 		{g_strModelCheckerContracts, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerDivModNoSlacks, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerEngine, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerExtCalls, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerInvariants, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerPrintQuery, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerShowProvedSafe, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
@@ -1069,7 +1070,6 @@ void CommandLineParser::processArgs()
 		{g_strModelCheckerSolvers, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerTimeout, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerBMCLoopIterations, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
-		{g_strModelCheckerContracts, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strModelCheckerTargets, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strViaSSACFG, {InputMode::Compiler, InputMode::CompilerWithASTImport, InputMode::Assembler}}
 	};

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -429,6 +429,7 @@ BOOST_AUTO_TEST_CASE(invalid_options_input_modes_combinations)
 		{"--model-checker-show-unsupported", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
 		{"--model-checker-div-mod-no-slacks", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
 		{"--model-checker-engine=bmc", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
+		{"--model-checker-ext-calls=trusted", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
 		{"--model-checker-invariants=contract,reentrancy", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
 		{"--model-checker-solvers=z3,smtlib2", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},
 		{"--model-checker-timeout=5", {"--strict-assembly", "--standard-json", "--link", "--import-asm-json"}},


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->

Fixes https://github.com/argotorg/solidity/issues/16975

`--model-checker-ext-calls` was missing from `validOptionInputModeCombinations`.

Because the option is parsed after the early returns for Standard JSON, linker and assembler modes, it could be explicitly supplied in those modes and then silently ignored.



## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [ ] No AI tools were used

<!-- If AI tools were used, describe which tools and for which parts here. -->

I use Codex to add test changes, and run the targeted verification. The resulting changes were reviewed and tested.