### PR TITLE
Assembler: Report an error on duplicate setimmutable for the same immutable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Compiler Features:
 * Yul Optimizer: Remove the ineffective elimination of unused `returndatacopy()` operations in simple cases from UnusedStoreEliminator.
 
 Bugfixes:
+* Assembler: Report an error instead of silently discarding the value when the Yul builtin `setimmutable` is called more than once for the same immutable within a single object.
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -47,6 +47,7 @@
 #include <fstream>
 #include <limits>
 #include <iterator>
+#include <set>
 #include <stack>
 
 using namespace solidity;
@@ -1036,11 +1037,17 @@ LinkerObject const& Assembly::assembleLegacy() const
 
 	bool setsImmutables = false;
 	bool pushesImmutables = false;
+	std::set<u256> assignedImmutables;
 
 	for (auto const& item: m_items)
 		if (item.type() == AssignImmutable)
 		{
 			item.setImmutableOccurrences(immutableReferencesBySub[item.data()].second.size());
+			assertThrow(
+				assignedImmutables.insert(item.data()).second,
+				AssemblyException,
+				"Immutable \"" + m_immutables.at(item.data()) + "\" is assigned more than once."
+			);
 			setsImmutables = true;
 		}
 		else if (item.type() == PushImmutable)

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -404,6 +404,33 @@ BOOST_AUTO_TEST_CASE(immutable)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(immutable_assigned_twice)
+{
+	// Regression test for https://github.com/argotorg/solidity/issues/16811 -
+	// assigning the same immutable twice used to silently drop the second write
+	// (it compiled down to a no-op POP; POP) instead of being rejected.
+	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
+	Assembly _assembly{evmVersion, true, {}};
+	_assembly.setSourceLocation({1, 3, std::make_shared<std::string>("root.asm")});
+
+	Assembly _subAsm{evmVersion, false, {}};
+	_subAsm.setSourceLocation({6, 8, std::make_shared<std::string>("sub.asm")});
+	_subAsm.appendImmutable("someImmutable");
+	std::shared_ptr<Assembly> _subAsmPtr = std::make_shared<Assembly>(_subAsm);
+
+	_assembly.append(u256(1));
+	_assembly.append(u256(0));
+	_assembly.appendImmutableAssignment("someImmutable");
+	_assembly.append(u256(2));
+	_assembly.append(u256(0));
+	_assembly.appendImmutableAssignment("someImmutable");
+
+	auto sub = _assembly.appendSubroutine(_subAsmPtr);
+	_assembly.pushSubroutineOffset(SubAssemblyID(sub.data()));
+
+	BOOST_CHECK_THROW(_assembly.assemble(), solidity::evmasm::AssemblyException);
+}
+
 BOOST_AUTO_TEST_CASE(subobject_encode_decode)
 {
 	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();


### PR DESCRIPTION
## Summary

Calling the Yul builtin `setimmutable(offset, name, value)` twice with the same `name` in a single object silently drops the **second** call. No error and no warning are produced. Only the first value reaches the immutable slot; the second (and any subsequent) call collapses to a no-op `POP; POP` in the deployed bytecode.

Root cause: in `libevmasm/Assembly.cpp` (the `AssignImmutable` arm of `Assembly::assembleLegacy()`), after the first `AssignImmutable` item for a given name is assembled, its recorded slot offsets are erased from `immutableReferencesBySub`. When a second `AssignImmutable` for the same name arrives, the map lookup returns an empty offsets vector, and the code silently emits `POP; POP` instead of reporting an error.

This fix tracks which immutables have already been assigned in the pre-pass that already walks `AssignImmutable` items (used to set `setImmutableOccurrences`), and raises an `AssemblyException` on a repeat — mirroring the existing sibling checks in the same function (e.g. `"Cannot push and assign immutables in the same assembly subroutine"`, `"More than one sub-assembly references immutables"`). This matches the minimum fix the issue itself calls out as acceptable, consistent with how the sibling case (`setimmutable`/`loadimmutable` in the same flat block) is already handled.

## Test plan

- Added `test/libevmasm/Assembler.cpp::immutable_assigned_twice`, which asserts that assembling a duplicate `setimmutable` for the same name throws `AssemblyException` (previously it silently produced valid-looking bytecode with the second write dropped).
- Verified the existing `immutable` and `all_assembly_items` test cases still pass — the legitimate single-assignment case (including assigning an immutable whose offsets list is empty because it's never read) continues to compile to `POP; POP` as before; only a second assignment for the same name is now rejected.
- Ran the full `Assembler` unit test suite (`soltest --run_test=Assembler`): 8/8 passing.

Fixes #16811
