### PR TITLE
Code Generator: Fix ICE from TupleType equality comparing pointers instead of types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Compiler Features:
 * Yul Optimizer: Remove the ineffective elimination of unused `returndatacopy()` operations in simple cases from UnusedStoreEliminator.
 
 Bugfixes:
+* Code Generator: Fix ICE (via IR) when assigning a tuple containing a calldata component (e.g. the result of a conditional expression involving calldata and memory variables) to a tuple of local variables, caused by `TupleType` equality incorrectly comparing component type pointers instead of the types they point to.
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2763,7 +2763,17 @@ std::string TupleType::richIdentifier() const
 bool TupleType::operator==(Type const& _other) const
 {
 	if (auto tupleType = dynamic_cast<TupleType const*>(&_other))
-		return components() == tupleType->components();
+	{
+		TypePointers const& others = tupleType->components();
+		if (components().size() != others.size())
+			return false;
+		return equal(
+			components().cbegin(),
+			components().cend(),
+			others.cbegin(),
+			[](Type const* _a, Type const* _b) -> bool { return _a == _b || (_a && _b && *_a == *_b); }
+		);
+	}
 	else
 		return false;
 }

--- a/test/libsolidity/semanticTests/array/calldata_memory_tuple_conditional.sol
+++ b/test/libsolidity/semanticTests/array/calldata_memory_tuple_conditional.sol
@@ -1,0 +1,21 @@
+contract C {
+    // Regression test for https://github.com/argotorg/solidity/issues/16066 -
+    // assigning a conditional expression whose branches are tuples mixing a memory
+    // and a calldata array to a tuple of local variables used to trigger an ICE
+    // under --via-ir.
+    function f(bool useOps1, uint[] calldata arr) external pure returns (uint sum) {
+        uint[] memory ops1 = new uint[](1);
+        ops1[0] = 1;
+        uint[] memory ops2 = new uint[](1);
+        ops2[0] = 2;
+
+        (uint[] memory a, uint[] calldata b) = useOps1 ? (ops1, arr) : (ops2, arr);
+
+        sum = a[0];
+        for (uint i = 0; i < b.length; i++)
+            sum += b[i];
+    }
+}
+// ----
+// f(bool,uint256[]): true, 0x40, 2, 10, 20 -> 31
+// f(bool,uint256[]): false, 0x40, 2, 10, 20 -> 32


### PR DESCRIPTION
## Summary

The compiler crashes with an internal compiler error under `--via-ir` on code like:

```solidity
contract Crash {
    function crashCompiler(bool conditional, uint[] calldata arr) external pure {
        uint[] memory ops1;
        uint[] memory ops2;

        (uint[] memory a, uint[] calldata b) = conditional ? (ops1, arr) : (ops2, arr);
    }
}
```

```
Internal compiler error:
libsolidity/codegen/YulUtilFunctions.cpp: Throw in function ... arrayConversionFunction(...)
```

### Root cause

`TupleType::operator==` compares the two tuples' component vectors with `std::vector<Type const*>::operator==`, which compares the **pointers themselves**, not the types they point to. Every sibling composite type dereferences its sub-components for comparison (`ArrayType::operator==` dereferences `baseType()`, `FunctionType::hasEqualParameterTypes` explicitly does `*_a == *_b` for each parameter pair) — `TupleType` was the one outlier doing shallow pointer-identity comparison.

`TupleType::mobileType()` builds a **fresh, non-interned** `TupleType` instance on every call (unlike e.g. `ArrayType`, whose instances are interned by `TypeProvider`). So two structurally identical tuple types compare unequal whenever they come from different call sites — which is exactly what happens for a conditional expression's inferred common type vs. the raw type of one of its branches.

In IR codegen, this makes `IRGeneratorForStatements::declareAssign`'s fast path (`_lhs.type() == _rhs.type()`) spuriously fail and fall through to `conversionFunctionSpecial`, which converts each tuple component via `YulUtilFunctions::conversionFunction`/`arrayConversionFunction` even when the two component types are actually identical. For the calldata array component, `arrayConversionFunction`'s very first check assumes any conversion targeting calldata must be a byte-array/string conversion (the only other caller that legitimately targets calldata), so it hits a `solAssert` and aborts.

### Fix

`TupleType::operator==` now dereferences and compares each component pair, following the same pattern as `FunctionType::hasEqualParameterTypes`, treating two null components (tuples can have omitted elements, e.g. `(x, , y)`) as equal to each other.

I confirmed this is the actual proximate cause via temporary debug instrumentation: before the fix, the conditional's inferred tuple type and the raw type of its true-branch tuple expression printed as structurally identical but compared unequal (different pointers); after the fix, they compare equal and `declareAssign`'s fast path is taken, avoiding the bogus conversion call entirely.

## Test plan

- Added `test/libsolidity/semanticTests/array/calldata_memory_tuple_conditional.sol`, which exercises the exact construct from the issue and additionally checks *correct values* out of both ternary branches (not just successful compilation), across both the legacy and via-IR pipelines (the default for semantic tests).
- Ran the full `syntaxTests` corpus (compile-only): 3473/3525 passing, 0 failures (52 pre-existing skips).
- Ran the full `semanticTests` corpus (real EVM execution via evmone): 1612/1684 passing, 0 failures (skips are pre-existing EVM-version-gated tests).
- Manually reproduced the original ICE with the unpatched compiler and confirmed it disappears with this fix, producing valid bytecode.

Fixes #16066
