### PR TITLE
Code Generator: Fix ICE emitting event with payable indexed function arg (via-IR)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Compiler Features:
 * Yul Optimizer: Remove the ineffective elimination of unused `returndatacopy()` operations in simple cases from UnusedStoreEliminator.
 
 Bugfixes:
+* Code Generator: Fix ICE (via IR) when emitting an event with an indexed external function parameter whose argument requires an implicit state mutability conversion (e.g. payable to non-payable).
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1094,8 +1094,12 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 						")\n";
 				else if (auto functionType = dynamic_cast<FunctionType const*>(paramTypes[i]))
 				{
+					// The argument's type may differ from the parameter type by an implicit
+					// conversion (e.g. payable to non-payable). This does not affect the runtime
+					// representation of an external function value (address, selector), so no
+					// actual conversion has to happen here.
 					solAssert(
-						IRVariable(arg).type() == *functionType &&
+						IRVariable(arg).type().isImplicitlyConvertibleTo(*functionType) &&
 						functionType->kind() == FunctionType::Kind::External &&
 						!functionType->hasBoundFirstArgument(),
 						""

--- a/test/libsolidity/semanticTests/events/event_indexed_function_payable_conversion.sol
+++ b/test/libsolidity/semanticTests/events/event_indexed_function_payable_conversion.sol
@@ -1,0 +1,10 @@
+contract C {
+    event Test(function() external indexed);
+    function f() public payable {}
+    function g() public {
+        emit Test(C(address(0x1234)).f);
+    }
+}
+// ----
+// g() ->
+// ~ emit Test(function): #0x123426121ff00000000000000000


### PR DESCRIPTION
## Summary

Emitting an event whose indexed parameter has an external function type triggers an internal compiler error under `--via-ir` whenever the argument's function type differs from the declared parameter type by state mutability:

```solidity
contract C {
    event E(function() external indexed);

    function f() public payable {
        emit E(this.f);
    }
}
```

```
solc --via-ir --bin ice.sol
Internal compiler error:
libsolidity/codegen/ir/IRGeneratorForStatements.cpp: Throw in function ... endVisit(const FunctionCall&)
```

Here `this.f` has type `function () external payable` while the event parameter is declared `function () external` (non-payable), so the emit requires the implicit payable-to-non-payable function conversion. That conversion is legal — the legacy pipeline compiles the contract fine — but IR codegen's handling of indexed function-type event arguments asserted the argument's `IRVariable` type was **exactly equal** to the declared parameter type instead of merely implicitly convertible to it:

```cpp
solAssert(
    IRVariable(arg).type() == *functionType &&
    ...
```

The runtime representation of an external function value is just `(address, selector)` regardless of its state mutability (`combineExternalFunctionIdFunction` only operates on those two stack values) — so no actual conversion needs to happen at this point in codegen; only the overly strict equality check was wrong.

## Fix

Relax the assertion to `IRVariable(arg).type().isImplicitlyConvertibleTo(*functionType)`, matching how the sibling checks elsewhere in this codebase (e.g. `YulUtilFunctions::conversionFunction`'s `FunctionType` branch) already validate legal-but-non-identical function type conversions.

## Test plan

- Added `test/libsolidity/semanticTests/events/event_indexed_function_payable_conversion.sol`. Since function selectors are unaffected by state mutability, the expected emitted log value is numerically identical to the existing `event_indexed_function.sol` baseline test — the only difference is `f` is declared `payable`, forcing the conversion that used to crash.
- Ran the full `semanticTests/events/*` suite: 45/45 passing (including both legacy and via-IR pipelines, the default for semantic tests).
- Ran the full `syntaxTests` corpus (compile-only): 3473/3525 passing, 0 failures (52 pre-existing skips).
- Ran the full `semanticTests` corpus (real EVM execution via evmone): 1612/1684 passing, 0 failures (skips are pre-existing EVM-version-gated tests).

Fixes #16888
