### PR TITLE
Fix legacy delete memory bytes element

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.37 (unreleased)
 
 Important Bugfixes:
+* Code Generator: Fix `delete` applied to an element of a `bytes` array in memory zeroing the whole 32-byte word starting at the element's location instead of only the element's byte.
 * Yul Optimizer: Fix too few memory slots being reserved when moving local variables to memory to work around stack-too-deep errors in code containing mutually recursive functions. Variables of two functions that can be active at the same time could be assigned the same slot, silently overwriting one of them while it was still in use.
 
 Language Features:

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,5 +1,17 @@
 [
     {
+        "uid": "SOL-2026-5",
+        "name": "MemoryByteArrayElementDeleteClearsWholeWord",
+        "summary": "Applying ``delete`` to a single element of a ``bytes`` array in memory clears not only that element but the whole 32-byte word starting at the element's location, zeroing up to 31 bytes beyond the element.",
+        "description": "Elements of ``bytes`` arrays in memory are packed, each occupying a single byte. When a value is assigned to such an element, the evmasm code generator correctly stores it with a single-byte ``MSTORE8`` instruction. The code path in the evmasm pipeline implementing ``delete`` on such an element, however, wrote the zero value with a full-word ``MSTORE``, clearing the 32 bytes starting at the element's location. The bytes following the element within the array were silently zeroed. If the element was within the last 31 bytes of the array's allocation, the write also extended past it into the area where the allocator places the next memory object, clearing the most significant bytes of that object's first word. How many elements are in reach depends on the size of the allocation: arrays created with ``new bytes(n)`` or from literals occupy their length rounded up to a multiple of 32 bytes, so only elements falling within the last 31 bytes of that rounded-up area, if any, could be affected. The results of ``bytes.concat``, ``string.concat``, and the ``abi.encode*`` functions, on the other hand, are placed by the evmasm pipeline in an allocation of exactly the size of their data, so the next object starts immediately after their last element and each of their last 31 elements is in reach. Assigning zero to an element (``b[i] = 0``) was not affected, only the ``delete`` operator, and neither were byte arrays in transient storage, storage, or calldata. The bug exists only in the evmasm pipeline. Code compiled via IR is unaffected. Optimizer settings have no influence. The defective code predates the first released version of the compiler.",
+        "link": "https://blog.soliditylang.org/2026/09/10/memory-byte-array-element-delete-clears-whole-word-bug/",
+        "fixed": "0.8.37",
+        "severity": "low/medium",
+        "conditions": {
+            "viaIR": false
+        }
+    },
+    {
         "uid": "SOL-2026-4",
         "name": "SpillSlotCollisionAcrossMutualRecursion",
         "summary": "Local variables of two simultaneously active functions moved to fixed memory offsets by the stack limit evader may be assigned the same offset if the call graph contains mutual recursion, so that one variable is silently overwritten by the other.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -1,6 +1,7 @@
 {
     "0.1.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -24,6 +25,7 @@
     },
     "0.1.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -47,6 +49,7 @@
     },
     "0.1.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -70,6 +73,7 @@
     },
     "0.1.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -93,6 +97,7 @@
     },
     "0.1.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -117,6 +122,7 @@
     },
     "0.1.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -141,6 +147,7 @@
     },
     "0.1.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -167,6 +174,7 @@
     },
     "0.1.7": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -193,6 +201,7 @@
     },
     "0.2.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -220,6 +229,7 @@
     },
     "0.2.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -247,6 +257,7 @@
     },
     "0.2.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -274,6 +285,7 @@
     },
     "0.3.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -303,6 +315,7 @@
     },
     "0.3.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -331,6 +344,7 @@
     },
     "0.3.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -359,6 +373,7 @@
     },
     "0.3.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -386,6 +401,7 @@
     },
     "0.3.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -413,6 +429,7 @@
     },
     "0.3.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -440,6 +457,7 @@
     },
     "0.3.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -465,6 +483,7 @@
     },
     "0.4.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -490,6 +509,7 @@
     },
     "0.4.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -515,6 +535,7 @@
     },
     "0.4.10": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -539,6 +560,7 @@
     },
     "0.4.11": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -562,6 +584,7 @@
     },
     "0.4.12": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -584,6 +607,7 @@
     },
     "0.4.13": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -606,6 +630,7 @@
     },
     "0.4.14": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -627,6 +652,7 @@
     },
     "0.4.15": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -647,6 +673,7 @@
     },
     "0.4.16": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -670,6 +697,7 @@
     },
     "0.4.17": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -694,6 +722,7 @@
     },
     "0.4.18": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -717,6 +746,7 @@
     },
     "0.4.19": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -741,6 +771,7 @@
     },
     "0.4.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -765,6 +796,7 @@
     },
     "0.4.20": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -789,6 +821,7 @@
     },
     "0.4.21": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -813,6 +846,7 @@
     },
     "0.4.22": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -837,6 +871,7 @@
     },
     "0.4.23": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -860,6 +895,7 @@
     },
     "0.4.24": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -883,6 +919,7 @@
     },
     "0.4.25": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -904,6 +941,7 @@
     },
     "0.4.26": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -922,6 +960,7 @@
     },
     "0.4.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -945,6 +984,7 @@
     },
     "0.4.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -967,6 +1007,7 @@
     },
     "0.4.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -992,6 +1033,7 @@
     },
     "0.4.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -1016,6 +1058,7 @@
     },
     "0.4.7": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -1040,6 +1083,7 @@
     },
     "0.4.8": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -1064,6 +1108,7 @@
     },
     "0.4.9": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "KeccakCaching",
@@ -1088,6 +1133,7 @@
     },
     "0.5.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1109,6 +1155,7 @@
     },
     "0.5.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1130,6 +1177,7 @@
     },
     "0.5.10": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1149,6 +1197,7 @@
     },
     "0.5.11": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1167,6 +1216,7 @@
     },
     "0.5.12": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1185,6 +1235,7 @@
     },
     "0.5.13": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1203,6 +1254,7 @@
     },
     "0.5.14": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1223,6 +1275,7 @@
     },
     "0.5.15": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1242,6 +1295,7 @@
     },
     "0.5.16": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1260,6 +1314,7 @@
     },
     "0.5.17": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1277,6 +1332,7 @@
     },
     "0.5.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1298,6 +1354,7 @@
     },
     "0.5.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1319,6 +1376,7 @@
     },
     "0.5.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1340,6 +1398,7 @@
     },
     "0.5.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1363,6 +1422,7 @@
     },
     "0.5.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1386,6 +1446,7 @@
     },
     "0.5.7": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "DirtyBytesArrayToStorage",
             "ABIDecodeTwoDimensionalArrayMemory",
@@ -1407,6 +1468,7 @@
     },
     "0.5.8": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1429,6 +1491,7 @@
     },
     "0.5.9": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1450,6 +1513,7 @@
     },
     "0.6.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1469,6 +1533,7 @@
     },
     "0.6.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
             "DirtyBytesArrayToStorage",
@@ -1487,6 +1552,7 @@
     },
     "0.6.10": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1504,6 +1570,7 @@
     },
     "0.6.11": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1521,6 +1588,7 @@
     },
     "0.6.12": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1538,6 +1606,7 @@
     },
     "0.6.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "MissingSideEffectsOnSelectorAccess",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
@@ -1557,6 +1626,7 @@
     },
     "0.6.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "MissingSideEffectsOnSelectorAccess",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
@@ -1576,6 +1646,7 @@
     },
     "0.6.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "MissingSideEffectsOnSelectorAccess",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
@@ -1595,6 +1666,7 @@
     },
     "0.6.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "MissingSideEffectsOnSelectorAccess",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
@@ -1614,6 +1686,7 @@
     },
     "0.6.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "MissingSideEffectsOnSelectorAccess",
             "AbiReencodingHeadOverflowWithStaticArrayCleanup",
@@ -1632,6 +1705,7 @@
     },
     "0.6.7": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1651,6 +1725,7 @@
     },
     "0.6.8": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1667,6 +1742,7 @@
     },
     "0.6.9": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1685,6 +1761,7 @@
     },
     "0.7.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1702,6 +1779,7 @@
     },
     "0.7.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "LostStorageArrayWriteOnSlotOverflow",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
             "MissingSideEffectsOnSelectorAccess",
@@ -1720,6 +1798,7 @@
     },
     "0.7.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1739,6 +1818,7 @@
     },
     "0.7.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1757,6 +1837,7 @@
     },
     "0.7.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1774,6 +1855,7 @@
     },
     "0.7.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1791,6 +1873,7 @@
     },
     "0.7.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1808,6 +1891,7 @@
     },
     "0.8.0": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1825,6 +1909,7 @@
     },
     "0.8.1": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1842,6 +1927,7 @@
     },
     "0.8.10": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1857,6 +1943,7 @@
     },
     "0.8.11": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1873,6 +1960,7 @@
     },
     "0.8.12": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1889,6 +1977,7 @@
     },
     "0.8.13": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1906,6 +1995,7 @@
     },
     "0.8.14": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1921,6 +2011,7 @@
     },
     "0.8.15": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1934,6 +2025,7 @@
     },
     "0.8.16": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1946,6 +2038,7 @@
     },
     "0.8.17": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1957,6 +2050,7 @@
     },
     "0.8.18": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1968,6 +2062,7 @@
     },
     "0.8.19": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1979,6 +2074,7 @@
     },
     "0.8.2": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -1996,6 +2092,7 @@
     },
     "0.8.20": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2007,6 +2104,7 @@
     },
     "0.8.21": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2016,6 +2114,7 @@
     },
     "0.8.22": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2025,6 +2124,7 @@
     },
     "0.8.23": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2033,6 +2133,7 @@
     },
     "0.8.24": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2041,6 +2142,7 @@
     },
     "0.8.25": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2049,6 +2151,7 @@
     },
     "0.8.26": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2057,6 +2160,7 @@
     },
     "0.8.27": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2065,6 +2169,7 @@
     },
     "0.8.28": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision",
@@ -2074,6 +2179,7 @@
     },
     "0.8.29": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
@@ -2084,6 +2190,7 @@
     },
     "0.8.3": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2100,6 +2207,7 @@
     },
     "0.8.30": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
@@ -2110,6 +2218,7 @@
     },
     "0.8.31": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
@@ -2120,6 +2229,7 @@
     },
     "0.8.32": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
@@ -2129,6 +2239,7 @@
     },
     "0.8.33": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
@@ -2138,6 +2249,7 @@
     },
     "0.8.34": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion"
@@ -2146,6 +2258,7 @@
     },
     "0.8.35": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion"
@@ -2154,12 +2267,14 @@
     },
     "0.8.36": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion"
         ],
         "released": "2026-07-09"
     },
     "0.8.4": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2175,6 +2290,7 @@
     },
     "0.8.5": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2191,6 +2307,7 @@
     },
     "0.8.6": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2207,6 +2324,7 @@
     },
     "0.8.7": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2223,6 +2341,7 @@
     },
     "0.8.8": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",
@@ -2240,6 +2359,7 @@
     },
     "0.8.9": {
         "bugs": [
+            "MemoryByteArrayElementDeleteClearsWholeWord",
             "SpillSlotCollisionAcrossMutualRecursion",
             "UnsoundSpillInMutualRecursion",
             "LostStorageArrayWriteOnSlotOverflow",

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -115,6 +115,9 @@ public:
 	/// Dynamic version of @see storeInMemory, expects the memory offset below the value on the stack
 	/// and also updates that. For reference types, only copies the data pointer. Fails for
 	/// non-memory-references. For string literals no value is available on the stack.
+	/// CAUTION: Even with @a _padToWords set to false, this may write a full 32-byte word and only
+	/// advance the offset by the unpadded size, i.e., up to 31 bytes past the reported end of the
+	/// stored value are overwritten.
 	/// @param _padToWords if true, adds zeros to pad to multiple of 32 bytes. Array elements
 	///                    are always padded (except for byte arrays), regardless of this parameter.
 	/// @param _cleanup if true, adds code to cleanup the value before storing it.

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -142,8 +142,21 @@ void MemoryItem::setToZero(SourceLocation const&, bool _removeReference) const
 	CompilerUtils utils(m_context);
 	solAssert(_removeReference, "");
 	utils.pushZeroValue(*m_dataType);
-	utils.storeInMemoryDynamic(*m_dataType, m_padded);
-	m_context << Instruction::POP;
+	// stack pre: reference 0
+	if (!m_padded)
+	{
+		solUnimplementedAssert(
+			m_dataType->calldataEncodedSize(/* _padded */ false) == 1,
+			"Zeroing of multi-byte non-padded types is not implemented."
+		);
+		solAssert(m_dataType->category() != Type::Category::UserDefinedValueType);
+		m_context << Instruction::SWAP1 << Instruction::MSTORE8;
+	}
+	else
+	{
+		utils.storeInMemoryDynamic(*m_dataType, m_padded);
+		m_context << Instruction::POP;
+	}
 }
 
 

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element.sol
@@ -1,0 +1,29 @@
+// `delete b[i]` on an element of a `bytes`/`string` in memory must clear exactly one byte, like `b[i] = 0`
+contract C {
+    function del0() external pure returns (bytes memory) {
+        bytes memory data = hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        delete data[0];
+        return data;
+    }
+
+    // The buffer is 5 bytes, so a full-word write from index 1 runs off the end of the payload.
+    function delShort() external pure returns (bytes memory) {
+        bytes memory data = hex"0102030405";
+        delete data[1];
+        return data;
+    }
+
+    // A `string memory` has no `[]`, but `bytes(s)` aliases the same memory,
+    // so the same defect corrupts a string in place
+    function delStringViaBytes() external pure returns (string memory) {
+        string memory s = "abcdefgh";
+        delete bytes(s)[2];
+        return s;
+    }
+}
+// ====
+// compileViaYul: false
+// ----
+// del0() -> 0x20, 0x20, 0
+// delShort() -> 0x20, 5, left(0x0100000000)
+// delStringViaBytes() -> 0x20, 8, "ab"

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element.sol
@@ -6,24 +6,20 @@ contract C {
         return data;
     }
 
-    // The buffer is 5 bytes, so a full-word write from index 1 runs off the end of the payload.
     function delShort() external pure returns (bytes memory) {
         bytes memory data = hex"0102030405";
         delete data[1];
         return data;
     }
 
-    // A `string memory` has no `[]`, but `bytes(s)` aliases the same memory,
-    // so the same defect corrupts a string in place
+    // A `string memory` has no `[]`, but `bytes(s)` aliases the same memory
     function delStringViaBytes() external pure returns (string memory) {
         string memory s = "abcdefgh";
         delete bytes(s)[2];
         return s;
     }
 }
-// ====
-// compileViaYul: false
 // ----
-// del0() -> 0x20, 0x20, 0
-// delShort() -> 0x20, 5, left(0x0100000000)
-// delStringViaBytes() -> 0x20, 8, "ab"
+// del0() -> 0x20, 0x20, 0x0002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// delShort() -> 0x20, 5, left(0x0100030405)
+// delStringViaBytes() -> 0x20, 8, "ab\x00defgh"

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_abi_encode_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_abi_encode_neighbor.sol
@@ -1,0 +1,83 @@
+// Companion to memory_bytes_delete_element_concat_neighbor.sol for byte arrays produced by the
+// `abi.encode*` functions. Under evmasm, the ABI encoder advances the free memory pointer by exactly
+// the encoded size and does not round up to a 32-byte boundary, so the next object starts right
+// after the last byte (E = D+L, P = 0) and a full-word write from index i reaches it for every
+// i >= L-31. Note that this includes `abi.encode`, whose result length is a multiple of 32 and
+// therefore never has padding, whichever allocator is used.
+interface I { function foo(uint8 a) external; }
+contract C {
+    struct S { uint256 x; }
+
+    // L=2, i=1, so the top 31 bytes of s.x are in reach
+    function encodePackedStructNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encodePacked(uint8(1), uint8(2));
+        S memory s = S(type(uint256).max);
+        delete b[1];
+        return s.x;
+    }
+
+    // L=2, i=1, so 31 bytes of the neighbor's length word are in reach and only the low byte of 300 = 0x012c survives
+    function encodePackedDynArrayNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encodePacked(uint8(1), uint8(2));
+        uint256[] memory a = new uint256[](300);
+        delete b[1];
+        return a.length;
+    }
+
+    // L=6, i=1, so bytes 2..5 of the payload are zeroed as well
+    function encodePackedPayload() external pure returns (bytes memory b) {
+        b = abi.encodePacked(hex"0102", hex"03040506");
+        delete b[1];
+    }
+
+    // L=36, i=35
+    function encodeWithSelectorDynArrayNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encodeWithSelector(I.foo.selector, uint8(1));
+        uint256[] memory a = new uint256[](300);
+        delete b[35];
+        return a.length;
+    }
+
+    // L=36, i=35
+    function encodeWithSignatureDynArrayNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encodeWithSignature("foo(uint8)", uint8(1));
+        uint256[] memory a = new uint256[](300);
+        delete b[35];
+        return a.length;
+    }
+
+    // L=36, i=35
+    function encodeCallDynArrayNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encodeCall(I.foo, (uint8(1)));
+        uint256[] memory a = new uint256[](300);
+        delete b[35];
+        return a.length;
+    }
+
+    // L=64, i=63
+    function encodeDynArrayNeighbor() external pure returns (uint256) {
+        bytes memory b = abi.encode(uint8(1), uint8(2));
+        uint256[] memory a = new uint256[](300);
+        delete b[63];
+        return a.length;
+    }
+
+    // L=64, i=33=L-31, so exactly the top byte of s.x is in reach
+    function encodeFarFromEnd() external pure returns (uint256) {
+        bytes memory b = abi.encode(uint8(1), uint8(2));
+        S memory s = S(type(uint256).max);
+        delete b[33];
+        return s.x;
+    }
+}
+// ====
+// compileViaYul: false
+// ----
+// encodePackedStructNeighbor() -> 0xff
+// encodePackedDynArrayNeighbor() -> 0x2c
+// encodePackedPayload() -> 0x20, 6, left(0x010000000000)
+// encodeWithSelectorDynArrayNeighbor() -> 0x2c
+// encodeWithSignatureDynArrayNeighbor() -> 0x2c
+// encodeCallDynArrayNeighbor() -> 0x2c
+// encodeDynArrayNeighbor() -> 0x2c
+// encodeFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_abi_encode_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_abi_encode_neighbor.sol
@@ -70,14 +70,12 @@ contract C {
         return s.x;
     }
 }
-// ====
-// compileViaYul: false
 // ----
-// encodePackedStructNeighbor() -> 0xff
-// encodePackedDynArrayNeighbor() -> 0x2c
-// encodePackedPayload() -> 0x20, 6, left(0x010000000000)
-// encodeWithSelectorDynArrayNeighbor() -> 0x2c
-// encodeWithSignatureDynArrayNeighbor() -> 0x2c
-// encodeCallDynArrayNeighbor() -> 0x2c
-// encodeDynArrayNeighbor() -> 0x2c
-// encodeFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// encodePackedStructNeighbor() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// encodePackedDynArrayNeighbor() -> 300
+// encodePackedPayload() -> 0x20, 6, left(0x010003040506)
+// encodeWithSelectorDynArrayNeighbor() -> 300
+// encodeWithSignatureDynArrayNeighbor() -> 300
+// encodeCallDynArrayNeighbor() -> 300
+// encodeDynArrayNeighbor() -> 300
+// encodeFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_concat_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_concat_neighbor.sol
@@ -66,14 +66,12 @@ contract C {
         return s;
     }
 }
-// ====
-// compileViaYul: false
 // ----
-// concatSingleByte() -> 0xff
-// concatFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// concatSingleByte() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// concatFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // concatDynArrayNeighborSurvives() -> 300
-// concatDynArrayNeighborTruncates() -> 0x2c
-// concatPayload() -> 0x20, 6, left(0x010000000000)
-// stringConcatSingleChar() -> 0xff
-// stringConcatDynArrayNeighborTruncates() -> 0x2c
-// stringConcatPayload() -> 0x20, 6, "a"
+// concatDynArrayNeighborTruncates() -> 300
+// concatPayload() -> 0x20, 6, left(0x010003040506)
+// stringConcatSingleChar() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// stringConcatDynArrayNeighborTruncates() -> 300
+// stringConcatPayload() -> 0x20, 6, "a\x00cdef"

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_concat_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_concat_neighbor.sol
@@ -1,0 +1,79 @@
+// Companion to memory_bytes_delete_element_neighbor.sol for byte arrays produced by `bytes.concat`
+// and `string.concat`. Under evmasm, both advance the free memory pointer by exactly the payload length and
+// does not round up to a 32-byte boundary, so the next object starts right after the last byte,
+// i.e. E = D+L and P = 0 regardless of L. Without padding to absorb it, a full-word write from
+// index i reaches the next object for every i >= L-31, and the number of spilled bytes is i+32-L.
+contract C {
+    struct S { uint256 x; }
+
+    // L=1, so a word written from index 0 covers the top 31 bytes of s.x
+    function concatSingleByte() external pure returns (uint256) {
+        bytes memory b = bytes.concat(bytes1(0x01));
+        S memory s = S(type(uint256).max);
+        delete b[0];
+        return s.x;
+    }
+
+    // L=33, i=2=L-31, so exactly the top byte of s.x is in reach
+    function concatFarFromEnd() external pure returns (uint256) {
+        bytes memory b = bytes.concat(new bytes(32), bytes1(0x01));
+        S memory s = S(type(uint256).max);
+        delete b[2];
+        return s.x;
+    }
+
+    // L=6, i=4, so 30 bytes of the neighbor's length word are in reach; 300 fits into the remaining two
+    function concatDynArrayNeighborSurvives() external pure returns (uint256) {
+        bytes memory b = bytes.concat(new bytes(5), bytes1(0x01));
+        uint256[] memory a = new uint256[](300);
+        delete b[4];
+        return a.length;
+    }
+
+    // L=6, i=5, so 31 bytes are in reach and only the low byte of the length (300 = 0x012c) survives
+    function concatDynArrayNeighborTruncates() external pure returns (uint256) {
+        bytes memory b = bytes.concat(new bytes(5), bytes1(0x01));
+        uint256[] memory a = new uint256[](300);
+        delete b[5];
+        return a.length;
+    }
+
+    // The payload itself: clearing index 1 of a 6-byte concat result must leave bytes 2..5 intact
+    function concatPayload() external pure returns (bytes memory) {
+        bytes memory b = bytes.concat(hex"0102", hex"03040506");
+        delete b[1];
+        return b;
+    }
+    // `string.concat` uses the same allocation, and `bytes(s)` aliases the string's memory. L=1.
+    function stringConcatSingleChar() external pure returns (uint256) {
+        string memory s = string.concat("a");
+        S memory t = S(type(uint256).max);
+        delete bytes(s)[0];
+        return t.x;
+    }
+
+    // L=6, i=5, so 31 bytes reach into the neighbour's length word
+    function stringConcatDynArrayNeighborTruncates() external pure returns (uint256) {
+        string memory s = string.concat("abc", "def");
+        uint256[] memory a = new uint256[](300);
+        delete bytes(s)[5];
+        return a.length;
+    }
+
+    function stringConcatPayload() external pure returns (string memory) {
+        string memory s = string.concat("ab", "cdef");
+        delete bytes(s)[1];
+        return s;
+    }
+}
+// ====
+// compileViaYul: false
+// ----
+// concatSingleByte() -> 0xff
+// concatFarFromEnd() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// concatDynArrayNeighborSurvives() -> 300
+// concatDynArrayNeighborTruncates() -> 0x2c
+// concatPayload() -> 0x20, 6, left(0x010000000000)
+// stringConcatSingleChar() -> 0xff
+// stringConcatDynArrayNeighborTruncates() -> 0x2c
+// stringConcatPayload() -> 0x20, 6, "a"

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_neighbor.sol
@@ -56,11 +56,9 @@ contract C {
         return s.x;
     }
 }
-// ====
-// compileViaYul: false
 // ----
-// structNeighborLastElement() -> 0xff
-// structNeighborOneShort() -> 0xffff
+// structNeighborLastElement() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// structNeighborOneShort() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // dynArrayNeighborSurvivesSmallCount() -> 5
-// dynArrayNeighborTruncatesLargeCount() -> 0
-// paddingImmunity() -> -1
+// dynArrayNeighborTruncatesLargeCount() -> 256
+// paddingImmunity() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_neighbor.sol
+++ b/test/libsolidity/semanticTests/array/delete/memory_bytes_delete_element_neighbor.sol
@@ -1,0 +1,66 @@
+// `delete b[i]` on a memory byte-array element must clear exactly one byte and leave the memory
+// after the buffer untouched. Prior to the MemoryByteArrayElementDeleteClearsWholeWord fix, the
+// compiler wrote a full 32-byte word under evmasm.
+// For a delete near the end of the buffer, that word spilled past it into the next object.
+//
+// Layout: a `bytes` array of length `L` is rounded up to `R = 32*ceil(L/32)` bytes, occupying `[D, D+R)`
+// with `P = R-L` padding bytes. `E = D+R` is the first byte past it and, under the bump allocator,
+// the start of the next object. If `delete b[i]` writes a word over [D+i, D+i+31], it reaches
+// past E into that object whenever i >= R-31.
+//
+// The spill always runs from E upward, i.e. over the most significant bytes of the next word:
+// - a struct or fixed-size array holds a value there and loses its top bytes;
+// - a dynamic array holds its length there, right-aligned, so the low bytes survive and it is
+//   truncated only once the element count is large enough to reach the overwritten bytes.
+contract C {
+    struct S { uint256 x; }
+
+    // L=32, P=0
+    function structNeighborLastElement() external pure returns (uint256) {
+        bytes memory b = new bytes(32);
+        S memory s = S(type(uint256).max);
+        delete b[31];
+        return s.x;
+    }
+
+    // L=32, P=0
+    function structNeighborOneShort() external pure returns (uint256) {
+        bytes memory b = new bytes(32);
+        S memory s = S(type(uint256).max);
+        delete b[30];
+        return s.x;
+    }
+
+    // A dynamic array neighbour with a small element count keeps all of its length in the low,
+    // unreachable byte E+31
+    function dynArrayNeighborSurvivesSmallCount() external pure returns (uint256) {
+        bytes memory b = new bytes(32);
+        uint256[] memory a = new uint256[](5);
+        delete b[31];
+        return a.length;
+    }
+
+    // With 256 elements the length needs byte E+30
+    function dynArrayNeighborTruncatesLargeCount() external pure returns (uint256) {
+        bytes memory b = new bytes(32);
+        uint256[] memory a = new uint256[](256);
+        delete b[31];
+        return a.length;
+    }
+
+    // L=1, so P=31
+    function paddingImmunity() external pure returns (uint256) {
+        bytes memory b = new bytes(1);
+        S memory s = S(type(uint256).max);
+        delete b[0];
+        return s.x;
+    }
+}
+// ====
+// compileViaYul: false
+// ----
+// structNeighborLastElement() -> 0xff
+// structNeighborOneShort() -> 0xffff
+// dynArrayNeighborSurvivesSmallCount() -> 5
+// dynArrayNeighborTruncatesLargeCount() -> 0
+// paddingImmunity() -> -1

--- a/test/libsolidity/syntaxTests/functionTypes/delete_external_function_selector_and_address.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/delete_external_function_selector_and_address.sol
@@ -1,0 +1,14 @@
+contract C {
+    struct S {
+        function() external f;
+    }
+
+    function test() public {
+        S memory s;
+        delete s.f.selector;
+        delete s.f.address;
+    }
+}
+// ----
+// TypeError 4247: (130-142): Expression has to be an lvalue.
+// TypeError 4247: (159-170): Expression has to be an lvalue.

--- a/test/libsolidity/syntaxTests/types/bytesNN_index_delete.sol
+++ b/test/libsolidity/syntaxTests/types/bytesNN_index_delete.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        bytes16 b;
+        delete b[5];
+    }
+}
+// ----
+// TypeError 4360: (78-82): Single bytes in fixed bytes arrays cannot be modified.


### PR DESCRIPTION
Applying `delete` to a single element of a `bytes` array in memory clears not only that element but the whole 32-byte word starting at the element's location, zeroing up to 31 bytes beyond the element. This PR adds reproducers and fixes that behavior.