### PR TITLE
Fix tag ID truncation in AssemblyItem::toSubAssemblyTag

### DIFF
--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -54,10 +54,12 @@ AssemblyItem AssemblyItem::toSubAssemblyTag(SubAssemblyID _subId) const
 {
 	assertThrow(data() < (u256(1) << 64), util::Exception, "Tag already has subassembly set.");
 	assertThrow(m_type == PushTag || m_type == Tag, util::Exception, "");
-	auto tag = static_cast<size_t>(u256(data()) & 0xffffffffffffffffULL);
+	uint64_t const tag = static_cast<uint64_t>(data());
+	if constexpr (sizeof(size_t) < sizeof(uint64_t))
+		assertThrow(tag <= std::numeric_limits<size_t>::max(), util::Exception, "Tag ID does not fit in size_t.");
 	AssemblyItem r = *this;
 	r.m_type = PushTag;
-	r.setPushTagSubIdAndTag(_subId, tag);
+	r.setPushTagSubIdAndTag(_subId, static_cast<size_t>(tag));
 	return r;
 }
 

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -535,6 +535,30 @@ BOOST_AUTO_TEST_CASE(can_be_functional)
 	BOOST_CHECK(!AssemblyItem(UndefinedItem).canBeFunctional());
 }
 
+BOOST_AUTO_TEST_CASE(to_sub_assembly_tag_preserves_tag_id)
+{
+	SubAssemblyID const subID{3};
+	auto packed = [&](u256 const& _tagID) { return ((u256(subID.value) + 1) << 64) | _tagID; };
+
+	BOOST_CHECK_EQUAL(AssemblyItem(Tag, 7).toSubAssemblyTag(subID).data(), packed(7));
+
+	// A tag ID that does not fit in 32 bits must either survive the conversion intact or be
+	// rejected. Truncating it to the lower 32 bits would silently produce a reference to a
+	// different tag on platforms where size_t is narrower than 64 bits, e.g. WebAssembly.
+	u256 const largeTagID = (u256(1) << 32) + 7;
+	AssemblyItem const largeTag(Tag, largeTagID);
+	if constexpr (sizeof(size_t) < sizeof(uint64_t))
+		BOOST_CHECK_THROW(largeTag.toSubAssemblyTag(subID), util::Exception);
+	else
+	{
+		AssemblyItem const pushTag = largeTag.toSubAssemblyTag(subID);
+		BOOST_CHECK_EQUAL(pushTag.type(), PushTag);
+		BOOST_CHECK_EQUAL(pushTag.data(), packed(largeTagID));
+		BOOST_CHECK(pushTag.splitForeignPushTag().first == subID);
+		BOOST_CHECK_EQUAL(pushTag.splitForeignPushTag().second, static_cast<size_t>(largeTagID));
+	}
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // end namespaces


### PR DESCRIPTION
Fixes #16947.

`toSubAssemblyTag` masked the tag ID to 64 bits and then stored it in a `size_t`. On 32-bit `size_t` (e.g. the WASM build) large IDs were truncated to the lower 32 bits and pointed at unrelated tags.

Keep the ID in a `uint64_t` and reject values that do not fit in `size_t`. Coverage for an ID above 2^32 is in `test/libevmasm/Assembler.cpp`.