### PR TITLE
Constant Evaluator: Fix fitsPrecisionExp over-charging bit length

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ Compiler Features:
 * Yul Optimizer: Remove the ineffective elimination of unused `returndatacopy()` operations in simple cases from UnusedStoreEliminator.
 
 Bugfixes:
+* Constant Evaluator: Fix `fitsPrecisionExp` over-charging bit length for constant exponentiation (`exp * (msb + 1)` → `exp * msb + 1`).
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Code Generator: Fix uninitialized internal function pointers being read from a packed storage slot with the wrong value when a subsequent variable in the slot holds a non-zero value.
 * Code Generator: Fix constants read in both checked and `unchecked` contexts within one contract getting the checked/unchecked semantics of whichever read was generated first via IR, which could remove a required overflow panic or introduce a spurious one.

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -60,7 +60,7 @@ bool fitsPrecisionExp(bigint const& _base, bigint const& _exp)
 	if (mostSignificantBaseBit > bitsMax) // _base >= 2 ^ 4096
 		return false;
 
-	bigint bitsNeeded = _exp * (mostSignificantBaseBit + 1);
+	bigint bitsNeeded = _exp * mostSignificantBaseBit + 1;
 
 	return bitsNeeded <= bitsMax;
 }

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_boundary.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_boundary.sol
@@ -1,0 +1,2 @@
+contract C { uint256 constant X = (2 ** 2049) / (2 ** 2049); }
+// ----

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_near_max.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_near_max.sol
@@ -1,0 +1,2 @@
+contract C { uint256 constant X = (2 ** 4095) / (2 ** 4095); }
+// ----

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_over_budget.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base2_over_budget.sol
@@ -1,0 +1,4 @@
+contract C { uint256 constant X = (2 ** 4096) / (2 ** 4096); }
+// ----
+// TypeError 2271: (35-44): Built-in binary operator ** cannot be applied to types int_const 2 and int_const 4096.
+// TypeError 2271: (49-58): Built-in binary operator ** cannot be applied to types int_const 2 and int_const 4096.

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base3_boundary.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base3_boundary.sol
@@ -1,0 +1,2 @@
+contract C { uint256 constant X = (3 ** 2049) / (3 ** 2049); }
+// ----

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base4_boundary.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_base4_boundary.sol
@@ -1,0 +1,2 @@
+contract C { uint256 constant X = (4 ** 1366) / (4 ** 1366); }
+// ----


### PR DESCRIPTION
## Description

`fitsPrecisionExp` charged `exp * (msb(base) + 1)` bits for constant `base ** exp`. `msb` is a zero-based bit position, so the `+1` belongs outside the product (`exp * msb + 1`). The old formula rejected powers that still fit in the 4096-bit budget (worst for base 2, e.g. `2 ** 2049`).

Fixes #16984.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
Assisted by AI tools for drafting the patch and tests; every change was reviewed and verified locally (`isoltest -t '*exp_limit*'` and a small boost `msb` micro-check of the old vs new formula).