### PR TITLE
Support compile-time evaluation of `keccak256`

### DIFF
--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -32,6 +32,7 @@
 
 #include <fmt/format.h>
 
+#include <functional>
 #include <limits>
 
 using namespace solidity;
@@ -71,6 +72,62 @@ bool fitsPrecisionBase2(bigint const& _mantissa, uint32_t _expBase2)
 	return fitsPrecisionBaseX(_mantissa, 1.0, _expBase2);
 }
 
+}
+
+std::optional<bytes> ConstantEvaluator::evaluateBinaryOperator(Token _operator, bytes const& _left, bytes const& _right)
+{
+	if (_left.size() != _right.size())
+		return std::nullopt;
+	// only bytes32 supported for now
+	if (_left.size() != 32)
+		return std::nullopt;
+
+	auto bitwiseOperation = [&](auto _operation) {
+		bytes result(_left.size());
+		for (std::size_t i = 0; i < _left.size(); ++i)
+			result[i] = _operation(_left[i], _right[i]);
+		return result;
+	};
+	switch (_operator)
+	{
+	case Token::BitAnd:
+		return bitwiseOperation(std::bit_and<uint8_t>{});
+	case Token::BitOr:
+		return bitwiseOperation(std::bit_or<uint8_t>{});
+	case Token::BitXor:
+		return bitwiseOperation(std::bit_xor<uint8_t>{});
+	default:
+		return std::nullopt;
+	}
+}
+
+std::optional<bytes> ConstantEvaluator::evaluateBinaryOperator(Token _operator, bytes const& _left, rational const&  _right)
+{
+	if (_operator != Token::SAR && _operator != Token::SHL)
+		return std::nullopt;
+	if (_left.size() != 32)
+		return std::nullopt;
+	if (_right.numerator() < 0 || _right.denominator() != 1)
+		return std::nullopt;
+
+	bytes result(_left.size());
+	unsigned bitWidth = static_cast<unsigned>(_left.size()) * 8;
+
+	if (_right.numerator() >= bitWidth)
+		return result;
+	unsigned shiftAmount = _right.numerator().convert_to<unsigned>();
+
+	bigint shiftedValue = fromBigEndian<bigint>(_left);
+	if (_operator == Token::SHL)
+	{
+		shiftedValue <<= shiftAmount;
+		shiftedValue &= (bigint(1) << bitWidth) - 1; // Mask bits out of width
+	}
+	else
+		shiftedValue >>= shiftAmount;
+
+	toBigEndian<bigint>(shiftedValue, result);
+	return result;
 }
 
 std::optional<rational> ConstantEvaluator::evaluateBinaryOperator(Token _operator, rational const& _left, rational const& _right)
@@ -234,6 +291,21 @@ std::optional<rational> ConstantEvaluator::evaluateUnaryOperator(Token _operator
 	}
 }
 
+std::optional<bytes> ConstantEvaluator::evaluateUnaryOperator(Token _operator, bytes const& _input)
+{
+	if (_operator != Token::BitNot)
+		return std::nullopt;
+	// Only fixed bytes of length 32 are supported for now
+	if (_input.size() != 32)
+		return std::nullopt;
+
+	bytes result(_input.size());
+	for (std::size_t i = 0; i < _input.size(); ++i)
+		result[i] = static_cast<std::uint8_t>(~_input[i]);
+
+	return result;
+}
+
 namespace
 {
 
@@ -248,21 +320,69 @@ TypedValue convertType(rational const& _value, Type const& _type)
 		else
 			return TypedValue{&_type, _value.numerator() / _value.denominator()};
 	}
-	else
-		return TypedValue{};
+	else if (auto const* fixedBytesType = dynamic_cast<FixedBytesType const*>(&_type))
+	{
+		// Only bytes32 is supported for now.
+		if (fixedBytesType->numBytes() != 32)
+			return TypedValue{};
+
+		if (
+			_value.denominator() != 1 ||
+			_value.numerator() < 0 ||
+			_value.numerator() > TypeProvider::integer(fixedBytesType->numBytes() * 8, IntegerType::Modifier::Unsigned)->max()
+		)
+			return TypedValue{};
+
+		u256 integerValue = u256(_value.numerator());
+		// toBigEndian always returns 32 bytes.
+		// If support for narrower bytesN is added, then unused high bytes need to be erased
+		bytes bytesRepresentation = toBigEndian(integerValue);
+		return TypedValue{&_type, bytesRepresentation};
+	}
+
+	return TypedValue{};
 }
 
 TypedValue convertType(std::string const& _value, Type const& _type)
 {
 	if (
-		_type.category() != Type::Category::StringLiteral &&
-		_type.category() != Type::Category::Array
+		_type.category() == Type::Category::StringLiteral ||
+		_type.category() == Type::Category::Array
+	)
+		return TypedValue{&_type, _value};
+	else if (_type.category() == Type::Category::FixedBytes)
+	{
+		auto const& fixedBytes = dynamic_cast<FixedBytesType const&>(_type);
+		// Only bytes32 is supported for now.
+		if (fixedBytes.numBytes() != 32)
+			return TypedValue{};
+
+		if (_value.size() > fixedBytes.numBytes())
+			return TypedValue{};
+
+		// Right pad with zeros to the full width
+		auto bytesValue = asBytes(_value);
+		bytesValue.resize(fixedBytes.numBytes(), 0);
+		return TypedValue{&_type, bytesValue};
+	}
+
+	return TypedValue{};
+}
+
+TypedValue convertType(bytes const& _value, Type const& _type)
+{
+	auto const* fixedBytes = dynamic_cast<FixedBytesType const*>(&_type);
+	if (
+		!fixedBytes ||
+		_value.size() != fixedBytes->numBytes() ||
+		fixedBytes->numBytes() != 32  // Supports only bytes32 for now
 	)
 		return TypedValue{};
+
 	return TypedValue{&_type, _value};
 }
 
-TypedValue convertType(TypedValue const& _value, Type const& _type)
+TypedValue convertType(TypedValue::Value const& _value, Type const& _type)
 {
 	return std::visit(util::GenericVisitor{
 		[&](std::string const& value) {
@@ -271,10 +391,18 @@ TypedValue convertType(TypedValue const& _value, Type const& _type)
 		[&](rational const& value) {
 			return convertType(value, _type);
 		},
+		[&](bytes const& value) {
+			return convertType(value, _type);
+		},
 		[&](std::monostate const&) {
 			return TypedValue{};
 		}
-	}, _value.value());
+	}, _value);
+}
+
+TypedValue convertType(TypedValue const& _typedValue, Type const& _type)
+{
+	return convertType(_typedValue.value(), _type);
 }
 
 TypedValue constantToTypedValue(Type const& _type)
@@ -355,20 +483,29 @@ void ConstantEvaluator::endVisit(UnaryOperation const& _operation)
 	if (!resultType)
 		return;
 	value = convertType(value, *resultType);
-	if (!value.isRational())
+
+	std::optional<TypedValue::Value> result = std::visit(util::GenericVisitor {
+		[&](rational const& _value) -> std::optional<TypedValue::Value> {
+			return evaluateUnaryOperator(_operation.getOperator(), _value);
+		},
+		[&](bytes const& _value) -> std::optional<TypedValue::Value> {
+			return evaluateUnaryOperator(_operation.getOperator(), _value);
+		},
+		[](std::string const&) -> std::optional<TypedValue::Value> { return std::nullopt; },
+		[](std::monostate const&) -> std::optional<TypedValue::Value> { return std::nullopt; }
+	}, value.value());
+
+	if (!result)
 		return;
 
-	if (std::optional<rational> result = evaluateUnaryOperator(_operation.getOperator(), value.asRational()))
-	{
-		TypedValue convertedValue = convertType(*result, *resultType);
-		if (!convertedValue.type())
-			m_errorReporter.fatalTypeError(
-				3667_error,
-				_operation.location(),
-				"Arithmetic error when computing constant value."
-			);
-		m_values[&_operation] = convertedValue;
-	}
+	TypedValue convertedResult = convertType(*result, *resultType);
+	if (!convertedResult.type())
+		m_errorReporter.fatalTypeError(
+			3667_error,
+			_operation.location(),
+			"Arithmetic error when computing constant value."
+		);
+	m_values[&_operation] = convertedResult;
 }
 
 void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
@@ -399,29 +536,45 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 		return;
 	}
 
+	bool isFixedBytesShift = [&]() {
+		if (_operation.getOperator() != Token::SAR && _operation.getOperator() != Token::SHL)
+			return false;
+		return
+			left.type()->category() == Type::Category::FixedBytes &&
+			(right.type()->category() == Type::Category::Integer || right.type()->category() == Type::Category::RationalNumber);
+	}();
+
 	left = convertType(left, *resultType);
-	right = convertType(right, *resultType);
-	if (
-		!left.isRational() ||
-		!right.isRational()
-	)
+	if (!isFixedBytesShift)
+		right = convertType(right, *resultType);
+
+	std::optional<TypedValue::Value> result = std::visit(util::GenericVisitor {
+		[&](rational const& _left, rational const& _right) -> std::optional<TypedValue::Value> {
+			return evaluateBinaryOperator(_operation.getOperator(), _left, _right);
+		},
+		[&](bytes const& _left, bytes const& _right) -> std::optional<TypedValue::Value> {
+			return evaluateBinaryOperator(_operation.getOperator(), _left, _right);
+		},
+		[&](bytes const& _left, rational const& _right) -> std::optional<TypedValue::Value> {
+			return evaluateBinaryOperator(_operation.getOperator(), _left, _right);
+		},
+		[](std::string const&, std::string const&) -> std::optional<TypedValue::Value> { return std::nullopt; },
+		[](std::monostate const&, std::monostate const&) -> std::optional<TypedValue::Value> { return std::nullopt; },
+		[](auto const&, auto const&) -> std::optional<TypedValue::Value> { return std::nullopt; }
+	}, left.value(), right.value());
+
+	if (!result)
 		return;
 
-	if (std::optional<rational> value = evaluateBinaryOperator(
-		_operation.getOperator(),
-		left.asRational(),
-		right.asRational()
-	))
-	{
-		TypedValue convertedValue = convertType(*value, *resultType);
-		if (!convertedValue.type())
-			m_errorReporter.fatalTypeError(
-				2643_error,
-				_operation.location(),
-				"Arithmetic error when computing constant value."
-			);
-		m_values[&_operation] = convertedValue;
-	}
+	TypedValue convertedValue = convertType(*result, *resultType);
+	if (!convertedValue.type())
+		m_errorReporter.fatalTypeError(
+			2643_error,
+			_operation.location(),
+			"Arithmetic error when computing constant value."
+		);
+	m_values[&_operation] = convertedValue;
+
 }
 
 void ConstantEvaluator::endVisit(Literal const& _literal)
@@ -500,6 +653,10 @@ TypedValue::TypedValue(Type const* _type, TypedValue::Value _value)
 		[&](rational const&) {
 			solAssert(dynamic_cast<RationalNumberType const*>(_type) || dynamic_cast<IntegerType const*>(_type));
 		},
+		[&](bytes const& _bytes) {
+			solAssert(dynamic_cast<FixedBytesType const*>(_type));
+			solAssert(dynamic_cast<FixedBytesType const*>(_type)->numBytes() == _bytes.size());
+		},
 		[&](std::monostate const&) {
 			solAssert(!_type);
 		}
@@ -521,4 +678,11 @@ rational const& TypedValue::asRational() const
 	auto const* rationalValue = std::get_if<rational>(&m_value);
 	solAssert(rationalValue);
 	return *rationalValue;
+}
+
+bytes const& TypedValue::asBytes() const
+{
+	auto const* bytesValue = std::get_if<bytes>(&m_value);
+	solAssert(bytesValue);
+	return *bytesValue;
 }

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -274,7 +274,7 @@ TypedValue convertType(TypedValue const& _value, Type const& _type)
 		[&](std::monostate const&) {
 			return TypedValue{};
 		}
-	}, _value.value);
+	}, _value.value());
 }
 
 TypedValue constantToTypedValue(Type const& _type)
@@ -348,20 +348,20 @@ TypedValue ConstantEvaluator::evaluate(ASTNode const& _node)
 void ConstantEvaluator::endVisit(UnaryOperation const& _operation)
 {
 	TypedValue value = evaluate(_operation.subExpression());
-	if (!value.type)
+	if (value.empty())
 		return;
 
-	Type const* resultType = value.type->unaryOperatorResult(_operation.getOperator());
+	Type const* resultType = value.type()->unaryOperatorResult(_operation.getOperator());
 	if (!resultType)
 		return;
 	value = convertType(value, *resultType);
-	if (!std::holds_alternative<rational>(value.value))
+	if (!value.isRational())
 		return;
 
-	if (std::optional<rational> result = evaluateUnaryOperator(_operation.getOperator(), std::get<rational>(value.value)))
+	if (std::optional<rational> result = evaluateUnaryOperator(_operation.getOperator(), value.asRational()))
 	{
 		TypedValue convertedValue = convertType(*result, *resultType);
-		if (!convertedValue.type)
+		if (!convertedValue.type())
 			m_errorReporter.fatalTypeError(
 				3667_error,
 				_operation.location(),
@@ -375,7 +375,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 {
 	TypedValue left = evaluate(_operation.leftExpression());
 	TypedValue right = evaluate(_operation.rightExpression());
-	if (!left.type || !right.type)
+	if (!left.type() || !right.type())
 		return;
 
 	// If this is implemented in the future: Comparison operators have a "binaryOperatorResult"
@@ -383,7 +383,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 	if (TokenTraits::isCompareOp(_operation.getOperator()))
 		return;
 
-	Type const* resultType = left.type->binaryOperatorResult(_operation.getOperator(), right.type);
+	Type const* resultType = left.type()->binaryOperatorResult(_operation.getOperator(), right.type());
 	if (!resultType)
 	{
 		m_errorReporter.fatalTypeError(
@@ -392,9 +392,9 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 			"Operator " +
 			std::string(TokenTraits::toString(_operation.getOperator())) +
 			" not compatible with types " +
-			left.type->toString() +
+			left.type()->toString() +
 			" and " +
-			right.type->toString()
+			right.type()->toString()
 			);
 		return;
 	}
@@ -402,19 +402,19 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 	left = convertType(left, *resultType);
 	right = convertType(right, *resultType);
 	if (
-		!std::holds_alternative<rational>(left.value) ||
-		!std::holds_alternative<rational>(right.value)
+		!left.isRational() ||
+		!right.isRational()
 	)
 		return;
 
 	if (std::optional<rational> value = evaluateBinaryOperator(
 		_operation.getOperator(),
-		std::get<rational>(left.value),
-		std::get<rational>(right.value)
+		left.asRational(),
+		right.asRational()
 	))
 	{
 		TypedValue convertedValue = convertType(*value, *resultType);
-		if (!convertedValue.type)
+		if (!convertedValue.type())
 			m_errorReporter.fatalTypeError(
 				2643_error,
 				_operation.location(),
@@ -468,7 +468,7 @@ void ConstantEvaluator::endVisit(FunctionCall const& _functionCall)
 				return;
 			}
 			auto stringArg = evaluate(*(_functionCall.arguments()[0].get()));
-			if (!std::holds_alternative<std::string>(stringArg.value))
+			if (!stringArg.isString())
 			{
 				m_errorReporter.typeError(
 					9796_error,
@@ -478,7 +478,7 @@ void ConstantEvaluator::endVisit(FunctionCall const& _functionCall)
 				return;
 			}
 
-			h256 innerKeccak = keccak256(std::get<std::string>(stringArg.value));
+			h256 innerKeccak = keccak256(stringArg.asString());
 			h256 outerKeccak = keccak256(h256(u256(innerKeccak) - 1));
 			outerKeccak.data()[31] = 0;
 			u256 slot = outerKeccak;
@@ -489,4 +489,36 @@ void ConstantEvaluator::endVisit(FunctionCall const& _functionCall)
 		default:
 			break;
 	}
+}
+
+TypedValue::TypedValue(Type const* _type, TypedValue::Value _value)
+{
+	std::visit(util::GenericVisitor{
+		[&](std::string const&) {
+			solAssert(dynamic_cast<StringLiteralType const*>(_type) || dynamic_cast<ArrayType const*>(_type));
+		},
+		[&](rational const&) {
+			solAssert(dynamic_cast<RationalNumberType const*>(_type) || dynamic_cast<IntegerType const*>(_type));
+		},
+		[&](std::monostate const&) {
+			solAssert(!_type);
+		}
+	}, _value);
+
+	m_type = _type;
+	m_value = std::move(_value);
+}
+
+std::string const& TypedValue::asString() const
+{
+	auto const* stringValue = std::get_if<std::string>(&m_value);
+	solAssert(stringValue);
+	return *stringValue;
+}
+
+rational const& TypedValue::asRational() const
+{
+	auto const* rationalValue = std::get_if<rational>(&m_value);
+	solAssert(rationalValue);
+	return *rationalValue;
 }

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -639,6 +639,20 @@ void ConstantEvaluator::endVisit(FunctionCall const& _functionCall)
 			m_values[&_functionCall] = TypedValue{functionType->returnParameterTypes()[0], rational{slot}};
 			break;
 		}
+		case FunctionType::Kind::KECCAK256:
+		{
+			if (_functionCall.arguments().size() != 1)
+				return;
+			auto argValue = evaluate(*_functionCall.arguments()[0]);
+			if (!argValue.isString())
+				return;
+
+			h256 hash = keccak256(argValue.asString());
+			solAssert(functionType->returnParameterTypes().size() == 1);
+			solAssert(functionType->returnParameterTypes()[0] == TypeProvider::fixedBytes(32));
+			m_values[&_functionCall] = TypedValue{functionType->returnParameterTypes()[0], hash.asBytes()};
+			break;
+		}
 		default:
 			break;
 	}

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -38,7 +38,7 @@ namespace solidity::frontend
 class TypeChecker;
 
 /**
- * Small drop-in replacement for TypeChecker to evaluate simple expressions of integer constants.
+ * Small drop-in replacement for TypeChecker to evaluate simple expressions of integer and string constants.
  *
  * Note: This always use "checked arithmetic" in the sense that any over- or underflow
  * results in "unknown" value.
@@ -46,11 +46,24 @@ class TypeChecker;
 class ConstantEvaluator: private ASTConstVisitor
 {
 public:
-	struct TypedValue
+	class TypedValue
 	{
+	public:
+		using Value = std::variant<std::monostate, rational, std::string>;
+
+		TypedValue(): m_type(nullptr), m_value(std::monostate()) {}
+		TypedValue(Type const* _type, Value _value);
+		bool empty() const { return std::holds_alternative<std::monostate>(m_value); }
+		bool isString() const { return std::holds_alternative<std::string>(m_value); }
+		bool isRational() const { return std::holds_alternative<rational>(m_value); }
+		Type const* type() const { return m_type; }
+		Value const& value() const { return m_value; }
+		std::string const& asString() const;
+		rational const& asRational() const;
+	private:
 		// Type may be RationalType or IntegerType for value rational
-		Type const* type;
-		std::variant<std::monostate, rational, std::string> value;
+		Type const* m_type;
+		Value m_value;
 	};
 
 	static TypedValue evaluate(

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -38,7 +38,7 @@ namespace solidity::frontend
 class TypeChecker;
 
 /**
- * Small drop-in replacement for TypeChecker to evaluate simple expressions of integer and string constants.
+ * Small drop-in replacement for TypeChecker to evaluate simple expressions of integer, string and fixed bytes constants.
  *
  * Note: This always use "checked arithmetic" in the sense that any over- or underflow
  * results in "unknown" value.
@@ -49,17 +49,19 @@ public:
 	class TypedValue
 	{
 	public:
-		using Value = std::variant<std::monostate, rational, std::string>;
+		using Value = std::variant<std::monostate, rational, std::string, bytes>;
 
 		TypedValue(): m_type(nullptr), m_value(std::monostate()) {}
 		TypedValue(Type const* _type, Value _value);
 		bool empty() const { return std::holds_alternative<std::monostate>(m_value); }
 		bool isString() const { return std::holds_alternative<std::string>(m_value); }
 		bool isRational() const { return std::holds_alternative<rational>(m_value); }
+		bool isBytes() const { return std::holds_alternative<bytes>(m_value); }
 		Type const* type() const { return m_type; }
 		Value const& value() const { return m_value; }
 		std::string const& asString() const;
 		rational const& asRational() const;
+		bytes const& asBytes() const;
 	private:
 		// Type may be RationalType or IntegerType for value rational
 		Type const* m_type;
@@ -75,13 +77,26 @@ public:
 	/// `TypedValue` containing `std::monostate` instead.
 	static TypedValue tryEvaluate(Expression const& _expr);
 
-	/// Performs arbitrary-precision evaluation of a binary operator. Returns nullopt on cases like
+	/// Performs arbitrary-precision evaluation of a binary operator for numeric types. Returns nullopt on cases like
 	/// division by zero or e.g. bit operators applied to fractional values.
 	static std::optional<rational> evaluateBinaryOperator(Token _operator, rational const& _left, rational const&  _right);
 
-	/// Performs arbitrary-precision evaluation of a unary operator. Returns nullopt on cases like
-	/// bit operators applied to fractional values.
+	/// Performs evaluation of a binary operator of fixed bytes types.
+	/// Returns nullopt if the operator is not allowed. Only supports bytes32.
+	static std::optional<bytes> evaluateBinaryOperator(Token _operator, bytes const& _left, bytes const&  _right);
+
+	/// Performs evaluation of shifts on fixed bytes.
+	/// Only supports bytes32. Returns nullopt for other lengths and invalid shift amounts.
+	static std::optional<bytes> evaluateBinaryOperator(Token _operator, bytes const& _left, rational const&  _right);
+
+	/// Performs arbitrary-precision evaluation of a unary operator for literal and integer type values.
+	/// Returns nullopt on cases like bit operators applied to fractional values.
 	static std::optional<rational> evaluateUnaryOperator(Token _operator, rational const& _input);
+
+	/// Performs evaluation of unary operator of fixed bytes.
+	/// Only supports bitwise negation `~` and fixed bytes of length 32.
+	/// Returns nullopt otherwise.
+	static std::optional<bytes> evaluateUnaryOperator(Token _operator, bytes const& _input);
 
 private:
 	explicit ConstantEvaluator(langutil::ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}

--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -339,9 +339,9 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 		if (length->annotation().type && length->annotation().type->category() == Type::Category::RationalNumber)
 			lengthValue = dynamic_cast<RationalNumberType const&>(*length->annotation().type).value();
 		else if (ConstantEvaluator::TypedValue value = ConstantEvaluator::evaluate(m_errorReporter, *length);
-			std::holds_alternative<rational>(value.value)
+			value.isRational()
 		)
-			lengthValue = std::get<rational>(value.value);
+			lengthValue = value.asRational();
 
 		if (!lengthValue)
 			m_errorReporter.typeError(

--- a/libsolidity/analysis/PostTypeContractLevelChecker.cpp
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.cpp
@@ -137,8 +137,8 @@ void PostTypeContractLevelChecker::checkStorageLayoutSpecifier(ContractDefinitio
 	if (integerType)
 	{
 		ConstantEvaluator::TypedValue typedRational = ConstantEvaluator::evaluate(m_errorReporter, baseSlotExpression);
-		solAssert(!typedRational.type || dynamic_cast<IntegerType const*>(typedRational.type));
-		if (!typedRational.type)
+		solAssert(!typedRational.type() || dynamic_cast<IntegerType const*>(typedRational.type()));
+		if (!typedRational.type())
 		{
 			m_errorReporter.typeError(
 				1505_error,
@@ -148,8 +148,8 @@ void PostTypeContractLevelChecker::checkStorageLayoutSpecifier(ContractDefinitio
 			);
 			return;
 		}
-		solAssert(std::holds_alternative<rational>(typedRational.value));
-		baseSlotRationalValue = std::get<rational>(typedRational.value);
+		solAssert(typedRational.isRational());
+		baseSlotRationalValue = typedRational.asRational();
 	}
 	else
 	{

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -314,12 +314,12 @@ bool StaticAnalyzer::visit(BinaryOperation const& _operation)
 	if (
 		*_operation.rightExpression().annotation().isPure &&
 		(_operation.getOperator() == Token::Div || _operation.getOperator() == Token::Mod) &&
-		ConstantEvaluator::evaluate(m_errorReporter, _operation.leftExpression()).type
+		ConstantEvaluator::evaluate(m_errorReporter, _operation.leftExpression()).type()
 	)
 		if (
 			auto rhs = ConstantEvaluator::evaluate(m_errorReporter, _operation.rightExpression());
-			std::holds_alternative<rational>(rhs.value) &&
-			std::get<rational>(rhs.value) == 0
+			rhs.isRational() &&
+			rhs.asRational() == 0
 		)
 			m_errorReporter.typeError(
 				1211_error,
@@ -342,8 +342,8 @@ bool StaticAnalyzer::visit(FunctionCall const& _functionCall)
 			if (*_functionCall.arguments()[2]->annotation().isPure)
 				if (
 					auto lastArg = ConstantEvaluator::evaluate(m_errorReporter, *(_functionCall.arguments())[2]);
-					std::holds_alternative<rational>(lastArg.value) &&
-					std::get<rational>(lastArg.value) == 0
+					lastArg.isRational() &&
+					lastArg.asRational() == 0
 				)
 					m_errorReporter.typeError(
 						4195_error,

--- a/libsolidity/ast/ASTUtils.cpp
+++ b/libsolidity/ast/ASTUtils.cpp
@@ -146,11 +146,11 @@ std::optional<u256> erc7201CompileTimeValue(FunctionCall const& _erc7201Call)
 
 	auto evaluatedResult = ConstantEvaluator::tryEvaluate(_erc7201Call);
 
-	if (std::holds_alternative<std::monostate>(evaluatedResult.value))
+	if (evaluatedResult.empty())
 		return std::nullopt;
 
-	solAssert(std::holds_alternative<rational>(evaluatedResult.value));
-	auto rationalValue = std::get<rational>(evaluatedResult.value);
+	solAssert(evaluatedResult.isRational());
+	auto rationalValue = evaluatedResult.asRational();
 	solAssert(rationalValue.denominator() == 1);
 	bigint baseSlot = rationalValue.numerator();
 	solAssert(baseSlot <= std::numeric_limits<u256>::max());

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -3125,9 +3125,9 @@ RationalNumberType const* SMTEncoder::isConstant(Expression const& _expr)
 
 	if (
 		auto typedValue = ConstantEvaluator::tryEvaluate(_expr);
-		std::holds_alternative<rational>(typedValue.value)
+		typedValue.isRational()
 	)
-		return TypeProvider::rationalNumber(std::get<rational>(typedValue.value));
+		return TypeProvider::rationalNumber(typedValue.asRational());
 
 	return nullptr;
 }

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_bitwise_operators.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_bitwise_operators.sol
@@ -1,0 +1,8 @@
+contract C {
+    bytes32 constant x = "abcdefgh";
+    bytes32 constant y = hex"00ffffffffffffff";
+
+    uint[((x & y) | (x ^ y)) & 1] z;
+}
+// ----
+// TypeError 6020: (108-131): Operator & not compatible with types bytes32 and int_const 1

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_from_number_literal.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_from_number_literal.sol
@@ -1,0 +1,7 @@
+contract C {
+    // TypeChecker has not yet run when `a` is evaluated in the array length
+    bytes32 constant x = 1;
+    uint[x & 1] y;
+}
+// ----
+// TypeError 6020: (127-132): Operator & not compatible with types bytes32 and int_const 1

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_narrower_than_32_bytes.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_narrower_than_32_bytes.sol
@@ -1,0 +1,6 @@
+contract C {
+    bytes4 constant x = "abcdefgh";
+    uint[x & 1] y;
+}
+// ----
+// TypeError 5462: (58-63): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_shift_larger_than_type.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_shift_larger_than_type.sol
@@ -1,0 +1,6 @@
+contract C {
+    bytes32 constant x = "abcdefgh";
+    uint[(x << 300) ^ 1] y;
+}
+// ----
+// TypeError 6020: (59-73): Operator ^ not compatible with types bytes32 and int_const 1

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_shift_operators.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_shift_operators.sol
@@ -1,0 +1,9 @@
+contract C {
+    bytes32 constant fixedBytes = "abcdefgh";
+    uint8 constant shiftAmount = 8;
+    uint[fixedBytes << shiftAmount] x;
+    uint[fixedBytes >> shiftAmount] y;
+}
+// ----
+// TypeError 5462: (104-129): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (143-168): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_unary_operator.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_unary_operator.sol
@@ -1,0 +1,6 @@
+contract C {
+    bytes32 constant x = "abcdefgh";
+    uint[~x] array;
+}
+// ----
+// TypeError 5462: (59-61): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_values.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/fixed_bytes_values.sol
@@ -1,0 +1,13 @@
+contract C {
+    bytes32 constant fromShortLiteral = "abc";
+    bytes32 constant fromFullLiteral = "01234567890123456789012345678901";
+    bytes32 constant fromHexLiteral = hex"00ff";
+    bytes32 constant fromEmptyLiteral = "";
+    bytes32 constant fromOtherConstant = fromShortLiteral;
+    bytes32 constant negated = ~fromHexLiteral;
+    bytes32 constant bitwise = (fromShortLiteral & fromHexLiteral) | (fromShortLiteral ^ fromHexLiteral);
+    bytes32 constant shifted = (fromShortLiteral << 8) >> 4;
+    bytes32 constant shiftedOut = fromShortLiteral << 300;
+    bytes32 constant fromUnicode = unicode"日本語";
+
+}

--- a/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_bitwise_operations.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_bitwise_operations.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint[keccak256("test") & 1] and;
+    uint[keccak256("test") | 1] or;
+    uint[keccak256("test") ^ 1] xor;
+    uint[~keccak256("test")] not;
+}
+// ----
+// TypeError 6020: (22-43): Operator & not compatible with types bytes32 and int_const 1

--- a/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_constant_arg.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_constant_arg.sol
@@ -1,0 +1,5 @@
+bytes32 constant input = "abcdefgh";
+bytes32 constant k = keccak256(input);
+contract C layout at k{ }
+// ----
+// TypeError 7556: (68-73): Invalid type for argument in function call. Invalid implicit conversion from bytes32 to bytes memory requested. This function requires a single bytes argument. Use abi.encodePacked(...) to obtain the pre-0.5.0 behaviour or abi.encode(...) to use ABI encoding.

--- a/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_shift_operations.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/keccak256_builtin_shift_operations.sol
@@ -1,0 +1,7 @@
+contract C {
+    uint[keccak256("test") << 8] shiftL;
+    uint[keccak256("test") >> 16] shiftR;
+}
+// ----
+// TypeError 5462: (22-44): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (63-86): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/keccak256_builtin.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/keccak256_builtin.sol
@@ -1,0 +1,3 @@
+contract C layout at keccak256("layoutBase") {}
+// ----
+// TypeError 1763: (21-44): The base slot of the storage layout must evaluate to an integer (the type is 'bytes32' instead).


### PR DESCRIPTION
Implements #16421.

Introduces constant evaluation of the `keccak256` builtin function.
Support for `bytes32` constants is also added since the builtin needs it for argument and return values.
There are no user-visible changes because there is no comp-time context that uses bytes32 currently.

Also note that the commit containing the refactor of `TypedValue` is here for convenience.
I expected it to be merged already as part of another PR, but now I am tempted to move to its own PR...