### PR TITLE
docs: point README priorities link at live GitHub project

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Please follow the
 if you want to help.
 
 You can find our current feature and bug priorities for forthcoming
-releases in the [projects section](https://github.com/argotorg/solidity/projects).
+releases in the [Solidity GitHub project](https://github.com/orgs/argotorg/projects/38).
 
 ## Maintainers
 The Solidity programming language and compiler are open-source community projects governed by a core team.


### PR DESCRIPTION
## Summary
README Development section links feature/bug priorities to `https://github.com/argotorg/solidity/projects`, which returns **HTTP 400** (classic Projects UI is gone for this org).

The live board is already documented in the contributing guide as [Solidity GitHub project](https://github.com/orgs/argotorg/projects/38).

## Repro
1. Open tip `README.md` → Development → “projects section”.
2. `curl -sI https://github.com/argotorg/solidity/projects` → 400.
3. `curl -sI https://github.com/orgs/argotorg/projects/38` → 200.
4. Same replacement URL appears in https://docs.soliditylang.org/en/latest/contributing.html.

## Change
Retarget the README link to `https://github.com/orgs/argotorg/projects/38`.